### PR TITLE
Add seats and units to default email templates

### DIFF
--- a/negotiated-nightly-booking/templates/counter-offer/counter-offer-html.html
+++ b/negotiated-nightly-booking/templates/counter-offer/counter-offer-html.html
@@ -27,22 +27,56 @@
       <tbody>
       {{#each tx-line-items}}
         {{#contains include-for recipient-role}}
-          <tr>
-            {{#eq "line-item/day" code}}
-            <td>{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "day" "days"}}</td>
-            <td style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</td>
-            {{/eq}}
+          {{#eq "line-item/day" code}}
+            <tr>
+              <td>Price per day</td>
+              <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
+            </tr>
+            {{#if seats}}
+            <tr>
+              <td>Days</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
+            </tr>
+            <tr>
+              <td>Seats</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
+            </tr>
+            {{else}}
+            <tr>
+              <td>Days</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
+            </tr>
+            {{/if}}
+          {{/eq}}
 
-            {{#eq "line-item/night" code}}
-            <td>{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "night" "nights"}}</td>
-            <td style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</td>
-            {{/eq}}
+          {{#eq "line-item/night" code}}
+            <tr>
+              <td>Price per night</td>
+              <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
+            </tr>
+            {{#if seats}}
+            <tr>
+              <td>Nights</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
+            </tr>
+            <tr>
+              <td>Seats</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
+            </tr>
+            {{else}}
+            <tr>
+              <td>Nights</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
+            </tr>
+            {{/if}}
+          {{/eq}}
 
-            {{#eq "line-item/negotiation" code}}
-            <td>Negotiation:</td>
-            <td style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</td>
-            {{/eq}}
-          </tr>
+          {{#eq "line-item/negotiation" code}}
+            <tr>
+              <td>Negotiation:</td>
+              <td style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</td>
+            </tr>
+          {{/eq}}
         {{/contains}}
       {{/each}}
       </tbody>

--- a/negotiated-nightly-booking/templates/customer-paid/customer-paid-html.html
+++ b/negotiated-nightly-booking/templates/customer-paid/customer-paid-html.html
@@ -23,28 +23,63 @@
       <tbody>
       {{#each tx-line-items}}
         {{#contains include-for "provider"}}
-          <tr>
-            {{#eq "line-item/day" code}}
-            <td>{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "day" "days"}}</td>
-            <td style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</td>
-            {{/eq}}
+          {{#eq "line-item/day" code}}
+            <tr>
+              <td>Price per day</td>
+              <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
+            </tr>
+            {{#if seats}}
+            <tr>
+              <td>Days</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
+            </tr>
+            <tr>
+              <td>Seats</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
+            </tr>
+            {{else}}
+            <tr>
+              <td>Days</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
+            </tr>
+            {{/if}}
+          {{/eq}}
 
-            {{#eq "line-item/night" code}}
-            <td>{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "night" "nights"}}</td>
-            <td style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</td>
-            {{/eq}}
+          {{#eq "line-item/night" code}}
+            <tr>
+              <td>Price per night</td>
+              <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
+            </tr>
+            {{#if seats}}
+            <tr>
+              <td>Nights</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
+            </tr>
+            <tr>
+              <td>Seats</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
+            </tr>
+            {{else}}
+            <tr>
+              <td>Nights</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
+            </tr>
+            {{/if}}
+          {{/eq}}
 
-            {{#eq "line-item/negotiation" code}}
-            <td>Negotiation:</td>
-            <td style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</td>
-            {{/eq}}
+          {{#eq "line-item/negotiation" code}}
+            <tr>
+              <td>Negotiation:</td>
+              <td style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</td>
+            </tr>
+          {{/eq}}
 
-            {{#eq "line-item/provider-commission" code}}
-            <td>{{marketplace.name}} fee:</td>
-            <td style="text-align: right; padding-left: 20px;">{{> format-money money=line-total}}</td>
-            {{/eq}}
-
-          </tr>
+          {{#eq "line-item/provider-commission" code}}
+            <tr>
+              <td>{{marketplace.name}} fee:</td>
+              <td style="text-align: right; padding-left: 20px;">{{> format-money money=line-total}}</td>
+            </tr>
+          {{/eq}}
         {{/contains}}
       {{/each}}
       </tbody>

--- a/negotiated-nightly-booking/templates/money-paid/money-paid-html.html
+++ b/negotiated-nightly-booking/templates/money-paid/money-paid-html.html
@@ -25,23 +25,64 @@
       <tbody>
       {{#each tx-line-items}}
         {{#contains include-for "provider"}}
-          <tr>
-            {{#eq "line-item/day" code}}
-            <td>{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "day" "days"}}</td>
-            <td style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</td>
-            {{/eq}}
+          {{#eq "line-item/day" code}}
+            <tr>
+              <td>Price per day</td>
+              <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
+            </tr>
+            {{#if seats}}
+            <tr>
+              <td>Days</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
+            </tr>
+            <tr>
+              <td>Seats</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
+            </tr>
+            {{else}}
+            <tr>
+              <td>Days</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
+            </tr>
+            {{/if}}
+            <tr>
+              <th style="text-align: left;">Subtotal</th>
+              <th style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</th>
+            </tr>
+          {{/eq}}
 
-            {{#eq "line-item/night" code}}
-            <td>{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "night" "nights"}}</td>
-            <td style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</td>
-            {{/eq}}
+          {{#eq "line-item/night" code}}
+            <tr>
+              <td>Price per night</td>
+              <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
+            </tr>
+            {{#if seats}}
+            <tr>
+              <td>Nights</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
+            </tr>
+            <tr>
+              <td>Seats</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
+            </tr>
+            {{else}}
+            <tr>
+              <td>Nights</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
+            </tr>
+            {{/if}}
+            <tr>
+              <th style="text-align: left;">Subtotal</th>
+              <th style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</th>
+            </tr>
+          {{/eq}}
 
-            {{#eq "line-item/provider-commission" code}}
-            <td>{{marketplace.name}} fee:</td>
-            <td style="text-align: right; padding-left: 20px;">{{> format-money money=line-total}}</td>
-            {{/eq}}
-          </tr>
-        {{/contains}}
+          {{#eq "line-item/provider-commission" code}}
+            </tr>
+              <td>{{marketplace.name}} fee:</td>
+              <td style="text-align: right; padding-left: 20px;">{{> format-money money=line-total}}</td>
+            </tr>
+          {{/eq}}        {{/contains}}
       {{/each}}
       </tbody>
       <tfoot>

--- a/negotiated-nightly-booking/templates/new-booking-request-with-offer/new-booking-request-with-offer-html.html
+++ b/negotiated-nightly-booking/templates/new-booking-request-with-offer/new-booking-request-with-offer-html.html
@@ -23,23 +23,56 @@
       <tbody>
       {{#each tx-line-items}}
         {{#contains include-for "provider"}}
-          <tr>
-            {{#eq "line-item/day" code}}
-            <td>{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "day" "days"}}</td>
-            <td style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</td>
-            {{/eq}}
+          {{#eq "line-item/day" code}}
+            <tr>
+              <td>Price per day</td>
+              <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
+            </tr>
+            {{#if seats}}
+            <tr>
+              <td>Days</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
+            </tr>
+            <tr>
+              <td>Seats</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
+            </tr>
+            {{else}}
+            <tr>
+              <td>Days</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
+            </tr>
+            {{/if}}
+          {{/eq}}
 
-            {{#eq "line-item/night" code}}
-            <td>{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "night" "nights"}}</td>
-            <td style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</td>
-            {{/eq}}
+          {{#eq "line-item/night" code}}
+            <tr>
+              <td>Price per night</td>
+              <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
+            </tr>
+            {{#if seats}}
+            <tr>
+              <td>Nights</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
+            </tr>
+            <tr>
+              <td>Seats</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
+            </tr>
+            {{else}}
+            <tr>
+              <td>Nights</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
+            </tr>
+            {{/if}}
+          {{/eq}}
 
-            {{#eq "line-item/negotiation" code}}
-            <td>Negotiation:</td>
-            <td style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</td>
-            {{/eq}}
-
-          </tr>
+          {{#eq "line-item/negotiation" code}}
+            <tr>
+              <td>Negotiation:</td>
+              <td style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</td>
+            </tr>
+          {{/eq}}
         {{/contains}}
       {{/each}}
       </tbody>

--- a/negotiated-nightly-booking/templates/provider-accepted-offer/provider-accepted-offer-html.html
+++ b/negotiated-nightly-booking/templates/provider-accepted-offer/provider-accepted-offer-html.html
@@ -23,27 +23,63 @@
       <tbody>
       {{#each tx-line-items}}
         {{#contains include-for "customer"}}
-          <tr>
-            {{#eq "line-item/day" code}}
-            <td>{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "day" "days"}}</td>
-            <td style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</td>
-            {{/eq}}
+          {{#eq "line-item/day" code}}
+            <tr>
+              <td>Price per day</td>
+              <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
+            </tr>
+            {{#if seats}}
+            <tr>
+              <td>Days</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
+            </tr>
+            <tr>
+              <td>Seats</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
+            </tr>
+            {{else}}
+            <tr>
+              <td>Days</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
+            </tr>
+            {{/if}}
+          {{/eq}}
 
-            {{#eq "line-item/night" code}}
-            <td>{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "night" "nights"}}</td>
-            <td style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</td>
-            {{/eq}}
+          {{#eq "line-item/night" code}}
+            <tr>
+              <td>Price per night</td>
+              <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
+            </tr>
+            {{#if seats}}
+            <tr>
+              <td>Nights</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
+            </tr>
+            <tr>
+              <td>Seats</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
+            </tr>
+            {{else}}
+            <tr>
+              <td>Nights</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
+            </tr>
+            {{/if}}
+          {{/eq}}
 
-            {{#eq "line-item/negotiation" code}}
-            <td>Negotiation:</td>
-            <td style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</td>
-            {{/eq}}
+          {{#eq "line-item/negotiation" code}}
+            <tr>
+              <td>Negotiation:</td>
+              <td style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</td>
+            </tr>
+          {{/eq}}
 
-            {{#eq "line-item/customer-commission" code}}
-            <td>{{marketplace.name}} fee:</td>
-            <td style="text-align: right; padding-left: 20px;">{{> format-money money=line-total}}</td>
-            {{/eq}}
-          </tr>
+          {{#eq "line-item/customer-commission" code}}
+            <tr>
+              <td>{{marketplace.name}} fee:</td>
+              <td style="text-align: right; padding-left: 20px;">{{> format-money money=line-total}}</td>
+            </tr>
+          {{/eq}}
         {{/contains}}
       {{/each}}
       </tbody>

--- a/preauth-daily-booking/templates/booking-request-accepted/booking-request-accepted-html.html
+++ b/preauth-daily-booking/templates/booking-request-accepted/booking-request-accepted-html.html
@@ -25,16 +25,49 @@
       <tbody>
       {{#each tx-line-items}}
         {{#contains include-for "customer"}}
-          <tr>
-            {{#eq "line-item/day" code}}
-            <td>{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "day" "days"}}</td>
-            <td style="padding-left: 20px;">{{> format-money money=line-total}}</td>
-            {{/eq}}
-            {{#eq "line-item/night" code}}
-            <td>{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "night" "nights"}}</td>
-            <td style="padding-left: 20px;">{{> format-money money=line-total}}</td>
-            {{/eq}}
-          </tr>
+          {{#eq "line-item/day" code}}
+              <tr>
+                <td>Price per day</td>
+                <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
+              </tr>
+              {{#if seats}}
+              <tr>
+                <td>Days</td>
+                <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
+              </tr>
+              <tr>
+                <td>Seats</td>
+                <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
+              </tr>
+              {{else}}
+              <tr>
+                <td>Days</td>
+                <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
+              </tr>
+              {{/if}}
+          {{/eq}}
+
+          {{#eq "line-item/night" code}}
+            <tr>
+              <td>Price per night</td>
+              <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
+            </tr>
+            {{#if seats}}
+            <tr>
+              <td>Nights</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
+            </tr>
+            <tr>
+              <td>Seats</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
+            </tr>
+            {{else}}
+            <tr>
+              <td>Nights</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
+            </tr>
+            {{/if}}
+          {{/eq}}
         {{/contains}}
       {{/each}}
       </tbody>

--- a/preauth-daily-booking/templates/money-paid/money-paid-html.html
+++ b/preauth-daily-booking/templates/money-paid/money-paid-html.html
@@ -25,22 +25,64 @@
       <tbody>
       {{#each tx-line-items}}
         {{#contains include-for "provider"}}
-          <tr>
-            {{#eq "line-item/day" code}}
-            <td>{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "day" "days"}}</td>
-            <td style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</td>
-            {{/eq}}
+          {{#eq "line-item/day" code}}
+            <tr>
+              <td>Price per day</td>
+              <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
+            </tr>
+            {{#if seats}}
+            <tr>
+              <td>Days</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
+            </tr>
+            <tr>
+              <td>Seats</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
+            </tr>
+            {{else}}
+            <tr>
+              <td>Days</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
+            </tr>
+            {{/if}}
+            <tr>
+              <th style="text-align: left;">Subtotal</th>
+              <th style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</th>
+            </tr>
+          {{/eq}}
 
-            {{#eq "line-item/night" code}}
-            <td>{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "night" "nights"}}</td>
-            <td style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</td>
-            {{/eq}}
+          {{#eq "line-item/night" code}}
+            <tr>
+              <td>Price per night</td>
+              <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
+            </tr>
+            {{#if seats}}
+            <tr>
+              <td>Nights</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
+            </tr>
+            <tr>
+              <td>Seats</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
+            </tr>
+            {{else}}
+            <tr>
+              <td>Nights</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
+            </tr>
+            {{/if}}
+            <tr>
+              <th style="text-align: left;">Subtotal</th>
+              <th style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</th>
+            </tr>
+          {{/eq}}
 
             {{#eq "line-item/provider-commission" code}}
+            </tr>
             <td>{{marketplace.name}} fee:</td>
             <td style="text-align: right; padding-left: 20px;">{{> format-money money=line-total}}</td>
+            </tr>
             {{/eq}}
-          </tr>
         {{/contains}}
       {{/each}}
       </tbody>

--- a/preauth-daily-booking/templates/new-booking-request/new-booking-request-html.html
+++ b/preauth-daily-booking/templates/new-booking-request/new-booking-request-html.html
@@ -23,22 +23,64 @@
       <tbody>
       {{#each tx-line-items}}
         {{#contains include-for "provider"}}
-          <tr>
-            {{#eq "line-item/day" code}}
-            <td>{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "day" "days"}}</td>
-            <td style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</td>
-            {{/eq}}
+          {{#eq "line-item/day" code}}
+            <tr>
+              <td>Price per day</td>
+              <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
+            </tr>
+            {{#if seats}}
+            <tr>
+              <td>Days</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
+            </tr>
+            <tr>
+              <td>Seats</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
+            </tr>
+            {{else}}
+            <tr>
+              <td>Days</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
+            </tr>
+            {{/if}}
+            <tr>
+              <th style="text-align: left;">Subtotal</th>
+              <th style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</th>
+            </tr>
+          {{/eq}}
 
-            {{#eq "line-item/night" code}}
-            <td>{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "night" "nights"}}</td>
-            <td style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</td>
-            {{/eq}}
+          {{#eq "line-item/night" code}}
+            <tr>
+              <td>Price per night</td>
+              <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
+            </tr>
+            {{#if seats}}
+            <tr>
+              <td>Nights</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
+            </tr>
+            <tr>
+              <td>Seats</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
+            </tr>
+            {{else}}
+            <tr>
+              <td>Nights</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
+            </tr>
+            {{/if}}
+            <tr>
+              <th style="text-align: left;">Subtotal</th>
+              <th style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</th>
+            </tr>
+          {{/eq}}
 
-            {{#eq "line-item/provider-commission" code}}
-            <td>{{marketplace.name}} fee:</td>
-            <td style="text-align: right; padding-left: 20px;">{{> format-money money=line-total}}</td>
-            {{/eq}}
-          </tr>
+          {{#eq "line-item/provider-commission" code}}
+            <tr>
+              <td>{{marketplace.name}} fee</td>
+              <td style="text-align: right; padding-left: 20px;">{{> format-money money=line-total}}</td>
+            </tr>
+          {{/eq}}
         {{/contains}}
       {{/each}}
       </tbody>

--- a/preauth-nightly-booking/templates/booking-request-accepted/booking-request-accepted-html.html
+++ b/preauth-nightly-booking/templates/booking-request-accepted/booking-request-accepted-html.html
@@ -25,16 +25,49 @@
       <tbody>
       {{#each tx-line-items}}
         {{#contains include-for "customer"}}
-          <tr>
-            {{#eq "line-item/day" code}}
-            <td>{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "day" "days"}}</td>
-            <td style="padding-left: 20px;">{{> format-money money=line-total}}</td>
-            {{/eq}}
-            {{#eq "line-item/night" code}}
-            <td>{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "night" "nights"}}</td>
-            <td style="padding-left: 20px;">{{> format-money money=line-total}}</td>
-            {{/eq}}
-          </tr>
+          {{#eq "line-item/day" code}}
+              <tr>
+                <td>Price per day</td>
+                <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
+              </tr>
+              {{#if seats}}
+              <tr>
+                <td>Days</td>
+                <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
+              </tr>
+              <tr>
+                <td>Seats</td>
+                <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
+              </tr>
+              {{else}}
+              <tr>
+                <td>Days</td>
+                <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
+              </tr>
+              {{/if}}
+          {{/eq}}
+
+          {{#eq "line-item/night" code}}
+            <tr>
+              <td>Price per night</td>
+              <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
+            </tr>
+            {{#if seats}}
+            <tr>
+              <td>Nights</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
+            </tr>
+            <tr>
+              <td>Seats</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
+            </tr>
+            {{else}}
+            <tr>
+              <td>Nights</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
+            </tr>
+            {{/if}}
+          {{/eq}}
         {{/contains}}
       {{/each}}
       </tbody>

--- a/preauth-nightly-booking/templates/money-paid/money-paid-html.html
+++ b/preauth-nightly-booking/templates/money-paid/money-paid-html.html
@@ -25,22 +25,64 @@
       <tbody>
       {{#each tx-line-items}}
         {{#contains include-for "provider"}}
-          <tr>
-            {{#eq "line-item/day" code}}
-            <td>{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "day" "days"}}</td>
-            <td style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</td>
-            {{/eq}}
+          {{#eq "line-item/day" code}}
+            <tr>
+              <td>Price per day</td>
+              <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
+            </tr>
+            {{#if seats}}
+            <tr>
+              <td>Days</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
+            </tr>
+            <tr>
+              <td>Seats</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
+            </tr>
+            {{else}}
+            <tr>
+              <td>Days</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
+            </tr>
+            {{/if}}
+            <tr>
+              <th style="text-align: left;">Subtotal</th>
+              <th style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</th>
+            </tr>
+          {{/eq}}
 
-            {{#eq "line-item/night" code}}
-            <td>{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "night" "nights"}}</td>
-            <td style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</td>
-            {{/eq}}
+          {{#eq "line-item/night" code}}
+            <tr>
+              <td>Price per night</td>
+              <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
+            </tr>
+            {{#if seats}}
+            <tr>
+              <td>Nights</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
+            </tr>
+            <tr>
+              <td>Seats</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
+            </tr>
+            {{else}}
+            <tr>
+              <td>Nights</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
+            </tr>
+            {{/if}}
+            <tr>
+              <th style="text-align: left;">Subtotal</th>
+              <th style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</th>
+            </tr>
+          {{/eq}}
 
             {{#eq "line-item/provider-commission" code}}
+            </tr>
             <td>{{marketplace.name}} fee:</td>
             <td style="text-align: right; padding-left: 20px;">{{> format-money money=line-total}}</td>
+            </tr>
             {{/eq}}
-          </tr>
         {{/contains}}
       {{/each}}
       </tbody>

--- a/preauth-nightly-booking/templates/new-booking-request/new-booking-request-html.html
+++ b/preauth-nightly-booking/templates/new-booking-request/new-booking-request-html.html
@@ -23,22 +23,64 @@
       <tbody>
       {{#each tx-line-items}}
         {{#contains include-for "provider"}}
-          <tr>
-            {{#eq "line-item/day" code}}
-            <td>{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "day" "days"}}</td>
-            <td style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</td>
-            {{/eq}}
+          {{#eq "line-item/day" code}}
+            <tr>
+              <td>Price per day</td>
+              <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
+            </tr>
+            {{#if seats}}
+            <tr>
+              <td>Days</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
+            </tr>
+            <tr>
+              <td>Seats</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
+            </tr>
+            {{else}}
+            <tr>
+              <td>Days</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
+            </tr>
+            {{/if}}
+            <tr>
+              <th style="text-align: left;">Subtotal</th>
+              <th style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</th>
+            </tr>
+          {{/eq}}
 
-            {{#eq "line-item/night" code}}
-            <td>{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "night" "nights"}}</td>
-            <td style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</td>
-            {{/eq}}
+          {{#eq "line-item/night" code}}
+            <tr>
+              <td>Price per night</td>
+              <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
+            </tr>
+            {{#if seats}}
+            <tr>
+              <td>Nights</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
+            </tr>
+            <tr>
+              <td>Seats</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
+            </tr>
+            {{else}}
+            <tr>
+              <td>Nights</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
+            </tr>
+            {{/if}}
+            <tr>
+              <th style="text-align: left;">Subtotal</th>
+              <th style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</th>
+            </tr>
+          {{/eq}}
 
-            {{#eq "line-item/provider-commission" code}}
-            <td>{{marketplace.name}} fee:</td>
-            <td style="text-align: right; padding-left: 20px;">{{> format-money money=line-total}}</td>
-            {{/eq}}
-          </tr>
+          {{#eq "line-item/provider-commission" code}}
+            <tr>
+              <td>{{marketplace.name}} fee</td>
+              <td style="text-align: right; padding-left: 20px;">{{> format-money money=line-total}}</td>
+            </tr>
+          {{/eq}}
         {{/contains}}
       {{/each}}
       </tbody>

--- a/preauth-unit-booking/templates/booking-request-accepted/booking-request-accepted-html.html
+++ b/preauth-unit-booking/templates/booking-request-accepted/booking-request-accepted-html.html
@@ -25,16 +25,49 @@
       <tbody>
       {{#each tx-line-items}}
         {{#contains include-for "customer"}}
-          <tr>
-            {{#eq "line-item/day" code}}
-            <td>{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "day" "days"}}</td>
-            <td style="padding-left: 20px;">{{> format-money money=line-total}}</td>
-            {{/eq}}
-            {{#eq "line-item/night" code}}
-            <td>{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "night" "nights"}}</td>
-            <td style="padding-left: 20px;">{{> format-money money=line-total}}</td>
-            {{/eq}}
-          </tr>
+          {{#eq "line-item/day" code}}
+              <tr>
+                <td>Price per day</td>
+                <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
+              </tr>
+              {{#if seats}}
+              <tr>
+                <td>Days</td>
+                <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
+              </tr>
+              <tr>
+                <td>Seats</td>
+                <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
+              </tr>
+              {{else}}
+              <tr>
+                <td>Days</td>
+                <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
+              </tr>
+              {{/if}}
+          {{/eq}}
+
+          {{#eq "line-item/night" code}}
+            <tr>
+              <td>Price per night</td>
+              <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
+            </tr>
+            {{#if seats}}
+            <tr>
+              <td>Nights</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
+            </tr>
+            <tr>
+              <td>Seats</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
+            </tr>
+            {{else}}
+            <tr>
+              <td>Nights</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
+            </tr>
+            {{/if}}
+          {{/eq}}
         {{/contains}}
       {{/each}}
       </tbody>

--- a/preauth-unit-booking/templates/money-paid/money-paid-html.html
+++ b/preauth-unit-booking/templates/money-paid/money-paid-html.html
@@ -25,22 +25,64 @@
       <tbody>
       {{#each tx-line-items}}
         {{#contains include-for "provider"}}
-          <tr>
-            {{#eq "line-item/day" code}}
-            <td>{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "day" "days"}}</td>
-            <td style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</td>
-            {{/eq}}
+          {{#eq "line-item/day" code}}
+            <tr>
+              <td>Price per day</td>
+              <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
+            </tr>
+            {{#if seats}}
+            <tr>
+              <td>Days</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
+            </tr>
+            <tr>
+              <td>Seats</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
+            </tr>
+            {{else}}
+            <tr>
+              <td>Days</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
+            </tr>
+            {{/if}}
+            <tr>
+              <th style="text-align: left;">Subtotal</th>
+              <th style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</th>
+            </tr>
+          {{/eq}}
 
-            {{#eq "line-item/night" code}}
-            <td>{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "night" "nights"}}</td>
-            <td style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</td>
-            {{/eq}}
+          {{#eq "line-item/night" code}}
+            <tr>
+              <td>Price per night</td>
+              <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
+            </tr>
+            {{#if seats}}
+            <tr>
+              <td>Nights</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
+            </tr>
+            <tr>
+              <td>Seats</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
+            </tr>
+            {{else}}
+            <tr>
+              <td>Nights</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
+            </tr>
+            {{/if}}
+            <tr>
+              <th style="text-align: left;">Subtotal</th>
+              <th style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</th>
+            </tr>
+          {{/eq}}
 
             {{#eq "line-item/provider-commission" code}}
+            </tr>
             <td>{{marketplace.name}} fee:</td>
             <td style="text-align: right; padding-left: 20px;">{{> format-money money=line-total}}</td>
+            </tr>
             {{/eq}}
-          </tr>
         {{/contains}}
       {{/each}}
       </tbody>

--- a/preauth-unit-booking/templates/new-booking-request/new-booking-request-html.html
+++ b/preauth-unit-booking/templates/new-booking-request/new-booking-request-html.html
@@ -23,22 +23,64 @@
       <tbody>
       {{#each tx-line-items}}
         {{#contains include-for "provider"}}
-          <tr>
-            {{#eq "line-item/day" code}}
-            <td>{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "day" "days"}}</td>
-            <td style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</td>
-            {{/eq}}
+          {{#eq "line-item/day" code}}
+            <tr>
+              <td>Price per day</td>
+              <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
+            </tr>
+            {{#if seats}}
+            <tr>
+              <td>Days</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
+            </tr>
+            <tr>
+              <td>Seats</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
+            </tr>
+            {{else}}
+            <tr>
+              <td>Days</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
+            </tr>
+            {{/if}}
+            <tr>
+              <th style="text-align: left;">Subtotal</th>
+              <th style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</th>
+            </tr>
+          {{/eq}}
 
-            {{#eq "line-item/night" code}}
-            <td>{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "night" "nights"}}</td>
-            <td style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</td>
-            {{/eq}}
+          {{#eq "line-item/night" code}}
+            <tr>
+              <td>Price per night</td>
+              <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
+            </tr>
+            {{#if seats}}
+            <tr>
+              <td>Nights</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
+            </tr>
+            <tr>
+              <td>Seats</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
+            </tr>
+            {{else}}
+            <tr>
+              <td>Nights</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
+            </tr>
+            {{/if}}
+            <tr>
+              <th style="text-align: left;">Subtotal</th>
+              <th style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</th>
+            </tr>
+          {{/eq}}
 
-            {{#eq "line-item/provider-commission" code}}
-            <td>{{marketplace.name}} fee:</td>
-            <td style="text-align: right; padding-left: 20px;">{{> format-money money=line-total}}</td>
-            {{/eq}}
-          </tr>
+          {{#eq "line-item/provider-commission" code}}
+            <tr>
+              <td>{{marketplace.name}} fee</td>
+              <td style="text-align: right; padding-left: 20px;">{{> format-money money=line-total}}</td>
+            </tr>
+          {{/eq}}
         {{/contains}}
       {{/each}}
       </tbody>

--- a/preauth-unit-time-booking/templates/booking-request-accepted/booking-request-accepted-html.html
+++ b/preauth-unit-time-booking/templates/booking-request-accepted/booking-request-accepted-html.html
@@ -25,16 +25,49 @@
       <tbody>
       {{#each tx-line-items}}
         {{#contains include-for "customer"}}
-          <tr>
-            {{#eq "line-item/day" code}}
-            <td>{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "day" "days"}}</td>
-            <td style="padding-left: 20px;">{{> format-money money=line-total}}</td>
-            {{/eq}}
-            {{#eq "line-item/night" code}}
-            <td>{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "night" "nights"}}</td>
-            <td style="padding-left: 20px;">{{> format-money money=line-total}}</td>
-            {{/eq}}
-          </tr>
+          {{#eq "line-item/day" code}}
+              <tr>
+                <td>Price per day</td>
+                <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
+              </tr>
+              {{#if seats}}
+              <tr>
+                <td>Days</td>
+                <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
+              </tr>
+              <tr>
+                <td>Seats</td>
+                <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
+              </tr>
+              {{else}}
+              <tr>
+                <td>Days</td>
+                <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
+              </tr>
+              {{/if}}
+          {{/eq}}
+
+          {{#eq "line-item/night" code}}
+            <tr>
+              <td>Price per night</td>
+              <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
+            </tr>
+            {{#if seats}}
+            <tr>
+              <td>Nights</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
+            </tr>
+            <tr>
+              <td>Seats</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
+            </tr>
+            {{else}}
+            <tr>
+              <td>Nights</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
+            </tr>
+            {{/if}}
+          {{/eq}}
         {{/contains}}
       {{/each}}
       </tbody>

--- a/preauth-unit-time-booking/templates/money-paid/money-paid-html.html
+++ b/preauth-unit-time-booking/templates/money-paid/money-paid-html.html
@@ -25,22 +25,64 @@
       <tbody>
       {{#each tx-line-items}}
         {{#contains include-for "provider"}}
-          <tr>
-            {{#eq "line-item/day" code}}
-            <td>{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "day" "days"}}</td>
-            <td style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</td>
-            {{/eq}}
+          {{#eq "line-item/day" code}}
+            <tr>
+              <td>Price per day</td>
+              <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
+            </tr>
+            {{#if seats}}
+            <tr>
+              <td>Days</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
+            </tr>
+            <tr>
+              <td>Seats</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
+            </tr>
+            {{else}}
+            <tr>
+              <td>Days</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
+            </tr>
+            {{/if}}
+            <tr>
+              <th style="text-align: left;">Subtotal</th>
+              <th style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</th>
+            </tr>
+          {{/eq}}
 
-            {{#eq "line-item/night" code}}
-            <td>{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "night" "nights"}}</td>
-            <td style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</td>
-            {{/eq}}
+          {{#eq "line-item/night" code}}
+            <tr>
+              <td>Price per night</td>
+              <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
+            </tr>
+            {{#if seats}}
+            <tr>
+              <td>Nights</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
+            </tr>
+            <tr>
+              <td>Seats</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
+            </tr>
+            {{else}}
+            <tr>
+              <td>Nights</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
+            </tr>
+            {{/if}}
+            <tr>
+              <th style="text-align: left;">Subtotal</th>
+              <th style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</th>
+            </tr>
+          {{/eq}}
 
             {{#eq "line-item/provider-commission" code}}
+            </tr>
             <td>{{marketplace.name}} fee:</td>
             <td style="text-align: right; padding-left: 20px;">{{> format-money money=line-total}}</td>
+            </tr>
             {{/eq}}
-          </tr>
         {{/contains}}
       {{/each}}
       </tbody>

--- a/preauth-unit-time-booking/templates/new-booking-request/new-booking-request-html.html
+++ b/preauth-unit-time-booking/templates/new-booking-request/new-booking-request-html.html
@@ -23,22 +23,64 @@
       <tbody>
       {{#each tx-line-items}}
         {{#contains include-for "provider"}}
-          <tr>
-            {{#eq "line-item/day" code}}
-            <td>{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "day" "days"}}</td>
-            <td style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</td>
-            {{/eq}}
+          {{#eq "line-item/day" code}}
+            <tr>
+              <td>Price per day</td>
+              <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
+            </tr>
+            {{#if seats}}
+            <tr>
+              <td>Days</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
+            </tr>
+            <tr>
+              <td>Seats</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
+            </tr>
+            {{else}}
+            <tr>
+              <td>Days</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
+            </tr>
+            {{/if}}
+            <tr>
+              <th style="text-align: left;">Subtotal</th>
+              <th style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</th>
+            </tr>
+          {{/eq}}
 
-            {{#eq "line-item/night" code}}
-            <td>{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "night" "nights"}}</td>
-            <td style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</td>
-            {{/eq}}
+          {{#eq "line-item/night" code}}
+            <tr>
+              <td>Price per night</td>
+              <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
+            </tr>
+            {{#if seats}}
+            <tr>
+              <td>Nights</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
+            </tr>
+            <tr>
+              <td>Seats</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
+            </tr>
+            {{else}}
+            <tr>
+              <td>Nights</td>
+              <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
+            </tr>
+            {{/if}}
+            <tr>
+              <th style="text-align: left;">Subtotal</th>
+              <th style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</th>
+            </tr>
+          {{/eq}}
 
-            {{#eq "line-item/provider-commission" code}}
-            <td>{{marketplace.name}} fee:</td>
-            <td style="text-align: right; padding-left: 20px;">{{> format-money money=line-total}}</td>
-            {{/eq}}
-          </tr>
+          {{#eq "line-item/provider-commission" code}}
+            <tr>
+              <td>{{marketplace.name}} fee</td>
+              <td style="text-align: right; padding-left: 20px;">{{> format-money money=line-total}}</td>
+            </tr>
+          {{/eq}}
         {{/contains}}
       {{/each}}
       </tbody>


### PR DESCRIPTION
Updates templates rendering so that seats and units are rendered separately. Supports old line items which only contain a quantity attribute.