### PR TITLE
Update booking breakdown on tx email templates

### DIFF
--- a/negotiated-nightly-booking/templates/counter-offer/counter-offer-html.html
+++ b/negotiated-nightly-booking/templates/counter-offer/counter-offer-html.html
@@ -8,6 +8,31 @@
 {{~/inline~}}
 
 <html>
+  <head>
+    <style type="text/css">
+     table {
+       border-collapse: collapse;
+     }
+     .left {
+       text-align: left;
+     }
+     .right {
+       text-align: right;
+       padding-left: 20px;
+     }
+     .bottom-row > td {
+       padding-bottom: 5px;
+     }
+     .top-row {
+       border-top: 1px solid #CCC;
+     }
+     .top-row > td,
+     .top-row > th
+     {
+       padding-top: 5px;
+     }
+    </style>
+  </head>
   <body>
     {{#with transaction}}
     <h1>Please respond to the offer made by {{other-party.display-name}}</h1>
@@ -21,47 +46,49 @@
     <table>
       <thead>
         <tr>
-          <th style="text-align: left;">Payment</th>
+          <td class="left">Start date</td>
+          <td class="right">End date</td>
+        </tr>
+        <tr>
+          <th class="left">{{date booking.start format="EEEE"}}</th>
+          <th class="right">{{date booking.end format="EEEE"}}</th>
+        </tr>
+        <tr class="bottom-row">
+          <th class="left">{{date booking.start format="MMM d"}}</th>
+          <th class="right">{{date booking.end format="MMM d"}}</th>
         </tr>
       </thead>
       <tbody>
       {{#each tx-line-items}}
         {{#contains include-for recipient-role}}
           {{#eq "line-item/night" code}}
-            <tr>
-              <td>Price per night</td>
-              <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
-            </tr>
             {{#if seats}}
-            <tr>
-              <td>Nights</td>
-              <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
+            <tr class="top-row">
+              <td colspan="2">{{> format-money money=unit-price}} &times; {{number units}} {{inflect units "night" "nights"}}</td>
             </tr>
-            <tr>
-              <td>Seats</td>
-              <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
+            <tr class="bottom-row">
+              <td colspan="2">Seats &times; {{number seats}}</td>
             </tr>
             {{else}}
-            <tr>
-              <td>Nights</td>
-              <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
+            <tr class="top-row bottom-row">
+              <td colspan="2">{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "night" "nights"}}</td>
             </tr>
-            {{/if}}
+        {{/if}}
           {{/eq}}
 
           {{#eq "line-item/negotiation" code}}
-            <tr>
-              <td>Negotiation:</td>
-              <td style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</td>
+            <tr class="top-row bottom-row">
+              <td>Negotiation</td>
+              <td class="right">{{> format-money money=line-total}}</td>
             </tr>
           {{/eq}}
         {{/contains}}
       {{/each}}
       </tbody>
       <tfoot>
-        <tr>
-          <th style="text-align: left;">Total</th>
-          <th style="text-align: right; padding-left: 20px;">{{> format-money money=payin-total}}</th>
+        <tr class="top-row">
+          <th class="left">Total</th>
+          <th class="right">{{> format-money money=payin-total}}</th>
         </tr>
       </tfoot>
     </table>

--- a/negotiated-nightly-booking/templates/customer-paid/customer-paid-html.html
+++ b/negotiated-nightly-booking/templates/customer-paid/customer-paid-html.html
@@ -8,6 +8,31 @@
 {{~/inline~}}
 
 <html>
+  <head>
+    <style type="text/css">
+     table {
+       border-collapse: collapse;
+     }
+     .left {
+       text-align: left;
+     }
+     .right {
+       text-align: right;
+       padding-left: 20px;
+     }
+     .bottom-row > td {
+       padding-bottom: 5px;
+     }
+     .top-row {
+       border-top: 1px solid #CCC;
+     }
+     .top-row > td,
+     .top-row > th
+     {
+       padding-top: 5px;
+     }
+    </style>
+  </head>
   <body>
     {{#with transaction}}
     <h1>{{customer.display-name}} paid the booking!</h1>
@@ -17,54 +42,56 @@
     <table>
       <thead>
         <tr>
-          <th style="text-align: left;">Payment</th>
+          <td class="left">Start date</td>
+          <td class="right">End date</td>
+        </tr>
+        <tr>
+          <th class="left">{{date booking.start format="EEEE"}}</th>
+          <th class="right">{{date booking.end format="EEEE"}}</th>
+        </tr>
+        <tr class="bottom-row">
+          <th class="left">{{date booking.start format="MMM d"}}</th>
+          <th class="right">{{date booking.end format="MMM d"}}</th>
         </tr>
       </thead>
       <tbody>
       {{#each tx-line-items}}
         {{#contains include-for "provider"}}
           {{#eq "line-item/night" code}}
-            <tr>
-              <td>Price per night</td>
-              <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
-            </tr>
             {{#if seats}}
-            <tr>
-              <td>Nights</td>
-              <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
+            <tr class="top-row">
+              <td colspan="2">{{> format-money money=unit-price}} &times; {{number units}} {{inflect units "night" "nights"}}</td>
             </tr>
-            <tr>
-              <td>Seats</td>
-              <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
+            <tr class="bottom-row">
+              <td colspan="2">Seats &times; {{number seats}}</td>
             </tr>
             {{else}}
-            <tr>
-              <td>Nights</td>
-              <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
+            <tr class="top-row bottom-row">
+              <td colspan="2">{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "night" "nights"}}</td>
             </tr>
             {{/if}}
           {{/eq}}
 
           {{#eq "line-item/negotiation" code}}
-            <tr>
-              <td>Negotiation:</td>
-              <td style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</td>
+            <tr class="top-row">
+              <td>Negotiation</td>
+              <td class="right">{{> format-money money=line-total}}</td>
             </tr>
           {{/eq}}
 
           {{#eq "line-item/provider-commission" code}}
-            <tr>
-              <td>{{marketplace.name}} fee:</td>
-              <td style="text-align: right; padding-left: 20px;">{{> format-money money=line-total}}</td>
+            <tr class="bottom-row">
+              <td>{{marketplace.name}} fee</td>
+              <td class="right">{{> format-money money=line-total}}</td>
             </tr>
           {{/eq}}
         {{/contains}}
       {{/each}}
       </tbody>
       <tfoot>
-        <tr>
-          <th style="text-align: left;">You earn</th>
-          <th style="text-align: right; padding-left: 20px;">{{> format-money money=payout-total}}</th>
+        <tr class="top-row">
+          <th class="left">You'll make</th>
+          <th class="right">{{> format-money money=payout-total}}</th>
         </tr>
       </tfoot>
     </table>

--- a/negotiated-nightly-booking/templates/money-paid/money-paid-html.html
+++ b/negotiated-nightly-booking/templates/money-paid/money-paid-html.html
@@ -8,6 +8,31 @@
 {{~/inline~}}
 
 <html>
+  <head>
+    <style type="text/css">
+     table {
+         border-collapse: collapse;
+     }
+     .left {
+         text-align: left;
+     }
+     .right {
+         text-align: right;
+         padding-left: 20px;
+     }
+     .bottom-row > td {
+         padding-bottom: 5px;
+     }
+     .top-row {
+         border-top: 1px solid #CCC;
+     }
+     .top-row > td,
+     .top-row > th
+     {
+         padding-top: 5px;
+     }
+    </style>
+  </head>
   <body>
     {{#with transaction}}
     <h1>You have been paid {{> format-money money=payout-total}}</h1>
@@ -19,51 +44,56 @@
     <table>
       <thead>
         <tr>
-          <th style="text-align: left;">Payment</th>
+          <td class="left">Start date</td>
+          <td class="right">End date</td>
+        </tr>
+        <tr>
+          <th class="left">{{date booking.start format="EEEE"}}</th>
+          <th class="right">{{date booking.end format="EEEE"}}</th>
+        </tr>
+        <tr class="bottom-row">
+          <th class="left">{{date booking.start format="MMM d"}}</th>
+          <th class="right">{{date booking.end format="MMM d"}}</th>
         </tr>
       </thead>
       <tbody>
       {{#each tx-line-items}}
         {{#contains include-for "provider"}}
           {{#eq "line-item/night" code}}
-            <tr>
-              <td>Price per night</td>
-              <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
-            </tr>
             {{#if seats}}
-            <tr>
-              <td>Nights</td>
-              <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
+            <tr class="top-row">
+              <td colspan="2">{{> format-money money=unit-price}} &times; {{number units}} {{inflect units "night" "nights"}}</td>
             </tr>
-            <tr>
-              <td>Seats</td>
-              <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
+            <tr class="bottom-row">
+              <td colspan="2">Seats &times; {{number seats}}</td>
             </tr>
             {{else}}
-            <tr>
-              <td>Nights</td>
-              <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
+            <tr class="top-row bottom-row">
+              <td colspan="2">{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "night" "nights"}}</td>
             </tr>
             {{/if}}
-            <tr>
-              <th style="text-align: left;">Subtotal</th>
-              <th style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</th>
+          {{/eq}}
+
+          {{#eq "line-item/negotiation" code}}
+            <tr class="top-row">
+              <td>Negotiation</td>
+              <td class="right">{{> format-money money=line-total}}</td>
             </tr>
           {{/eq}}
 
           {{#eq "line-item/provider-commission" code}}
-            </tr>
-              <td>{{marketplace.name}} fee:</td>
-              <td style="text-align: right; padding-left: 20px;">{{> format-money money=line-total}}</td>
+            <tr class="bottom-row">
+              <td>{{marketplace.name}} fee</td>
+              <td class="right">{{> format-money money=line-total}}</td>
             </tr>
           {{/eq}}
         {{/contains}}
       {{/each}}
       </tbody>
       <tfoot>
-        <tr>
-          <th style="text-align: left;">You earn</th>
-          <th style="text-align: right; padding-left: 20px;">{{> format-money money=payout-total}}</th>
+        <tr class="top-row">
+          <th class="left">You'll make</th>
+          <th class="right">{{> format-money money=payout-total}}</th>
         </tr>
       </tfoot>
     </table>

--- a/negotiated-nightly-booking/templates/new-booking-request-with-offer/new-booking-request-with-offer-html.html
+++ b/negotiated-nightly-booking/templates/new-booking-request-with-offer/new-booking-request-with-offer-html.html
@@ -8,6 +8,31 @@
 {{~/inline~}}
 
 <html>
+  <head>
+    <style type="text/css">
+     table {
+       border-collapse: collapse;
+     }
+     .left {
+       text-align: left;
+     }
+     .right {
+       text-align: right;
+       padding-left: 20px;
+     }
+     .bottom-row > td {
+       padding-bottom: 5px;
+     }
+     .top-row {
+       border-top: 1px solid #CCC;
+     }
+     .top-row > td,
+     .top-row > th
+     {
+       padding-top: 5px;
+     }
+    </style>
+  </head>
   <body>
     {{#with transaction}}
     <h1>Please respond to a request by {{customer.display-name}}</h1>
@@ -17,47 +42,49 @@
     <table>
       <thead>
         <tr>
-          <th style="text-align: left;">Payment</th>
+          <td class="left">Start date</td>
+          <td class="right">End date</td>
+        </tr>
+        <tr>
+          <th class="left">{{date booking.start format="EEEE"}}</th>
+          <th class="right">{{date booking.end format="EEEE"}}</th>
+        </tr>
+        <tr class="bottom-row">
+          <th class="left">{{date booking.start format="MMM d"}}</th>
+          <th class="right">{{date booking.end format="MMM d"}}</th>
         </tr>
       </thead>
       <tbody>
       {{#each tx-line-items}}
         {{#contains include-for "provider"}}
           {{#eq "line-item/night" code}}
-            <tr>
-              <td>Price per night</td>
-              <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
-            </tr>
             {{#if seats}}
-            <tr>
-              <td>Nights</td>
-              <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
+            <tr class="top-row">
+              <td colspan="2">{{> format-money money=unit-price}} &times; {{number units}} {{inflect units "night" "nights"}}</td>
             </tr>
-            <tr>
-              <td>Seats</td>
-              <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
+            <tr class="bottom-row">
+              <td colspan="2">Seats &times; {{number seats}}</td>
             </tr>
             {{else}}
-            <tr>
-              <td>Nights</td>
-              <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
+            <tr class="top-row bottom-row">
+              <td colspan="2">{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "night" "nights"}}</td>
             </tr>
             {{/if}}
           {{/eq}}
 
           {{#eq "line-item/negotiation" code}}
-            <tr>
-              <td>Negotiation:</td>
-              <td style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</td>
+            <tr class="top-row bottom-row">
+              <td>Negotiation</td>
+              <td class="right">{{> format-money money=line-total}}</td>
             </tr>
           {{/eq}}
         {{/contains}}
       {{/each}}
       </tbody>
       <tfoot>
-        <tr>
-          <th style="text-align: left;">Total</th>
-          <th style="text-align: right; padding-left: 20px;">{{> format-money money=payout-total}}</th>
+        <tr class="top-row">
+          <th class="left">Total</th>
+          <th class="right">{{> format-money money=payout-total}}</th>
         </tr>
       </tfoot>
     </table>

--- a/negotiated-nightly-booking/templates/provider-accepted-offer/provider-accepted-offer-html.html
+++ b/negotiated-nightly-booking/templates/provider-accepted-offer/provider-accepted-offer-html.html
@@ -8,6 +8,31 @@
 {{~/inline~}}
 
 <html>
+  <head>
+    <style type="text/css">
+     table {
+       border-collapse: collapse;
+     }
+     .left {
+       text-align: left;
+     }
+     .right {
+       text-align: right;
+       padding-left: 20px;
+     }
+     .bottom-row > td {
+       padding-bottom: 5px;
+     }
+     .top-row {
+       border-top: 1px solid #CCC;
+     }
+     .top-row > td,
+     .top-row > th
+     {
+       padding-top: 5px;
+     }
+    </style>
+  </head>
   <body>
     <h1>Your offer was accepted!</h1>
 
@@ -17,54 +42,49 @@
     <table>
       <thead>
         <tr>
-          <th style="text-align: left;">Payment</th>
+          <td class="left">Start date</td>
+          <td class="right">End date</td>
+        </tr>
+        <tr>
+          <th class="left">{{date booking.start format="EEEE"}}</th>
+          <th class="right">{{date booking.end format="EEEE"}}</th>
+        </tr>
+        <tr class="bottom-row">
+          <th class="left">{{date booking.start format="MMM d"}}</th>
+          <th class="right">{{date booking.end format="MMM d"}}</th>
         </tr>
       </thead>
       <tbody>
       {{#each tx-line-items}}
         {{#contains include-for "customer"}}
           {{#eq "line-item/night" code}}
-            <tr>
-              <td>Price per night</td>
-              <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
-            </tr>
             {{#if seats}}
-            <tr>
-              <td>Nights</td>
-              <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
+            <tr class="top-row">
+                <td colspan="2">{{> format-money money=unit-price}} &times; {{number units}} {{inflect units "night" "nights"}}</td>
             </tr>
-            <tr>
-              <td>Seats</td>
-              <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
+            <tr class="bottom-row">
+                <td colspan="2">Seats &times; {{number seats}}</td>
             </tr>
             {{else}}
-            <tr>
-              <td>Nights</td>
-              <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
+            <tr class="top-row bottom-row">
+                <td colspan="2">{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "night" "nights"}}</td>
             </tr>
             {{/if}}
           {{/eq}}
 
           {{#eq "line-item/negotiation" code}}
-            <tr>
-              <td>Negotiation:</td>
-              <td style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</td>
-            </tr>
-          {{/eq}}
-
-          {{#eq "line-item/customer-commission" code}}
-            <tr>
-              <td>{{marketplace.name}} fee:</td>
-              <td style="text-align: right; padding-left: 20px;">{{> format-money money=line-total}}</td>
+            <tr class="top-row bottom-row">
+              <td>Negotiation</td>
+              <td class="right">{{> format-money money=line-total}}</td>
             </tr>
           {{/eq}}
         {{/contains}}
       {{/each}}
       </tbody>
       <tfoot>
-        <tr>
-          <th style="text-align: left;">Payment total</th>
-          <th style="text-align: right; padding-left: 20px;">{{> format-money money=payin-total}}</th>
+        <tr class="top-row">
+          <th class="left">Total</th>
+          <th class="right">{{> format-money money=payin-total}}</th>
         </tr>
       </tfoot>
     </table>

--- a/preauth-daily-booking/templates/booking-request-accepted/booking-request-accepted-html.html
+++ b/preauth-daily-booking/templates/booking-request-accepted/booking-request-accepted-html.html
@@ -12,6 +12,31 @@
 {{~/inline~}}
 
 <html>
+  <head>
+    <style type="text/css">
+     table {
+       border-collapse: collapse;
+     }
+     .left {
+       text-align: left;
+     }
+     .right {
+       text-align: right;
+       padding-left: 20px;
+     }
+     .bottom-row > td {
+       padding-bottom: 5px;
+     }
+     .top-row {
+       border-top: 1px solid #CCC;
+     }
+     .top-row > td,
+     .top-row > th
+     {
+       padding-top: 5px;
+     }
+    </style>
+  </head>
   <body>
     <h1>Your booking request was accepted!</h1>
 
@@ -23,40 +48,42 @@
     <table>
       <thead>
         <tr>
-          <th style="text-align: left;">Payment</th>
+          <td class="left">Start date</td>
+          <td class="right">End date</td>
+        </tr>
+        <tr>
+          <th class="left">{{date booking.start format="EEEE"}}</th>
+          <th class="right">{{date-day-before booking.end format="EEEE"}}</th>
+        </tr>
+        <tr class="bottom-row">
+          <th class="left">{{date booking.start format="MMM d"}}</th>
+          <th class="right">{{date-day-before booking.end format="MMM d"}}</th>
         </tr>
       </thead>
       <tbody>
       {{#each tx-line-items}}
         {{#contains include-for "customer"}}
           {{#eq "line-item/day" code}}
-              <tr>
-                <td>Price per day</td>
-                <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
-              </tr>
-              {{#if seats}}
-              <tr>
-                <td>Days</td>
-                <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
-              </tr>
-              <tr>
-                <td>Seats</td>
-                <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
-              </tr>
-              {{else}}
-              <tr>
-                <td>Days</td>
-                <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
-              </tr>
-              {{/if}}
+            {{#if seats}}
+            <tr class="top-row">
+              <td colspan="2">{{> format-money money=unit-price}} &times; {{number units}} {{inflect units "day" "days"}}</td>
+            </tr>
+            <tr class="bottom-row">
+              <td colspan="2">Seats &times; {{number seats}}</td>
+            </tr>
+            {{else}}
+            <tr class="top-row bottom-row">
+              <td colspan="2">{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "day" "days"}}</td>
+            </tr>
+            {{/if}}
           {{/eq}}
         {{/contains}}
       {{/each}}
       </tbody>
       <tfoot>
-        <tr>
-          <th style="text-align: left;">Payment total</th>
-          <th style="text-align: left; padding-left: 20px;">{{> format-money money=payin-total}}</th>
+        <tr class="top-row">
+          <th class="left">Total price</th>
+          <th class="right">{{> format-money money=payin-total}}</th>
         </tr>
       </tfoot>
     </table>

--- a/preauth-daily-booking/templates/money-paid/money-paid-html.html
+++ b/preauth-daily-booking/templates/money-paid/money-paid-html.html
@@ -12,6 +12,31 @@
 {{~/inline~}}
 
 <html>
+  <head>
+    <style type="text/css">
+     table {
+       border-collapse: collapse;
+     }
+     .left {
+       text-align: left;
+     }
+     .right {
+       text-align: right;
+       padding-left: 20px;
+     }
+     .bottom-row > td {
+       padding-bottom: 5px;
+     }
+     .top-row {
+       border-top: 1px solid #CCC;
+     }
+     .top-row > td,
+     .top-row > th
+     {
+       padding-top: 5px;
+     }
+    </style>
+  </head>
   <body>
     {{#with transaction}}
     <h1>You have been paid {{> format-money money=payout-total}}</h1>
@@ -23,51 +48,53 @@
     <table>
       <thead>
         <tr>
-          <th style="text-align: left;">Payment</th>
+          <td class="left">Start date</td>
+          <td class="right">End date</td>
+        </tr>
+        <tr>
+          <th class="left">{{date booking.start format="EEEE"}}</th>
+          <th class="right">{{date-day-before booking.end format="EEEE"}}</th>
+        </tr>
+        <tr class="bottom-row">
+          <th class="left">{{date booking.start format="MMM d"}}</th>
+          <th class="right">{{date-day-before booking.end format="MMM d"}}</th>
         </tr>
       </thead>
       <tbody>
       {{#each tx-line-items}}
         {{#contains include-for "provider"}}
           {{#eq "line-item/day" code}}
-            <tr>
-              <td>Price per day</td>
-              <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
-            </tr>
             {{#if seats}}
-            <tr>
-              <td>Days</td>
-              <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
+            <tr class="top-row">
+              <td colspan="2">{{> format-money money=unit-price}} &times; {{number units}} {{inflect units "day" "days"}}</td>
             </tr>
-            <tr>
-              <td>Seats</td>
-              <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
+            <tr class="bottom-row">
+              <td colspan="2">Seats &times; {{number seats}}</td>
             </tr>
             {{else}}
-            <tr>
-              <td>Days</td>
-              <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
+            <tr class="top-row bottom-row">
+              <td colspan="2">{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "day" "days"}}</td>
             </tr>
             {{/if}}
-            <tr>
-              <th style="text-align: left;">Subtotal</th>
-              <th style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</th>
+            <tr class="top-row">
+              <th class="left">Subtotal</th>
+              <th class="right">{{> format-money money=line-total}}</th>
             </tr>
           {{/eq}}
 
           {{#eq "line-item/provider-commission" code}}
-            </tr>
-              <td>{{marketplace.name}} fee:</td>
-              <td style="text-align: right; padding-left: 20px;">{{> format-money money=line-total}}</td>
+            <tr class="bottom-row">
+              <td>{{marketplace.name}} fee</td>
+              <td class="right">{{> format-money money=line-total}}</td>
             </tr>
           {{/eq}}
         {{/contains}}
       {{/each}}
       </tbody>
       <tfoot>
-        <tr>
-          <th style="text-align: left;">You earn</th>
-          <th style="text-align: right; padding-left: 20px;">{{> format-money money=payout-total}}</th>
+        <tr class="top-row">
+          <th class="left">You'll make</th>
+          <th class="right">{{> format-money money=payout-total}}</th>
         </tr>
       </tfoot>
     </table>

--- a/preauth-daily-booking/templates/new-booking-request/new-booking-request-html.html
+++ b/preauth-daily-booking/templates/new-booking-request/new-booking-request-html.html
@@ -12,6 +12,31 @@
 {{~/inline~}}
 
 <html>
+  <head>
+    <style type="text/css">
+     table {
+       border-collapse: collapse;
+     }
+     .left {
+       text-align: left;
+     }
+     .right {
+       text-align: right;
+       padding-left: 20px;
+     }
+     .bottom-row > td {
+       padding-bottom: 5px;
+     }
+     .top-row {
+       border-top: 1px solid #CCC;
+     }
+     .top-row > td,
+     .top-row > th
+     {
+       padding-top: 5px;
+     }
+    </style>
+  </head>
   <body>
     {{#with transaction}}
     <h1>Please respond to a request by {{customer.display-name}}</h1>
@@ -21,51 +46,53 @@
     <table>
       <thead>
         <tr>
-          <th style="text-align: left;">Payment</th>
+          <td class="left">Start date</td>
+          <td class="right">End date</td>
+        </tr>
+        <tr>
+          <th class="left">{{date booking.start format="EEEE"}}</th>
+          <th class="right">{{date-day-before booking.end format="EEEE"}}</th>
+        </tr>
+        <tr class="bottom-row">
+          <th class="left">{{date booking.start format="MMM d"}}</th>
+          <th class="right">{{date-day-before booking.end format="MMM d"}}</th>
         </tr>
       </thead>
       <tbody>
       {{#each tx-line-items}}
         {{#contains include-for "provider"}}
           {{#eq "line-item/day" code}}
-            <tr>
-              <td>Price per day</td>
-              <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
-            </tr>
             {{#if seats}}
-            <tr>
-              <td>Days</td>
-              <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
+            <tr class="top-row">
+              <td colspan="2">{{> format-money money=unit-price}} &times; {{number units}} {{inflect units "day" "days"}}</td>
             </tr>
-            <tr>
-              <td>Seats</td>
-              <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
+            <tr class="bottom-row">
+              <td colspan="2">Seats &times; {{number seats}}</td>
             </tr>
             {{else}}
-            <tr>
-              <td>Days</td>
-              <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
+            <tr class="top-row bottom-row">
+              <td colspan="2">{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "day" "days"}}</td>
             </tr>
             {{/if}}
-            <tr>
-              <th style="text-align: left;">Subtotal</th>
-              <th style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</th>
+            <tr class="top-row">
+              <th class="left">Subtotal</th>
+              <th class="right">{{> format-money money=line-total}}</th>
             </tr>
           {{/eq}}
 
           {{#eq "line-item/provider-commission" code}}
-            <tr>
+            <tr class="bottom-row">
               <td>{{marketplace.name}} fee</td>
-              <td style="text-align: right; padding-left: 20px;">{{> format-money money=line-total}}</td>
+              <td class="right">{{> format-money money=line-total}}</td>
             </tr>
           {{/eq}}
         {{/contains}}
       {{/each}}
       </tbody>
       <tfoot>
-        <tr>
-          <th style="text-align: left;">You earn</th>
-          <th style="text-align: left; padding-left: 20px;">{{> format-money money=payout-total}}</th>
+        <tr class="top-row">
+          <th class="left">You'll make</th>
+          <th class="right">{{> format-money money=payout-total}}</th>
         </tr>
       </tfoot>
     </table>

--- a/preauth-nightly-booking/templates/booking-request-accepted/booking-request-accepted-html.html
+++ b/preauth-nightly-booking/templates/booking-request-accepted/booking-request-accepted-html.html
@@ -8,6 +8,31 @@
 {{~/inline~}}
 
 <html>
+  <head>
+    <style type="text/css">
+     table {
+       border-collapse: collapse;
+     }
+     .left {
+       text-align: left;
+     }
+     .right {
+       text-align: right;
+       padding-left: 20px;
+     }
+     .bottom-row > td {
+       padding-bottom: 5px;
+     }
+     .top-row {
+       border-top: 1px solid #CCC;
+     }
+     .top-row > td,
+     .top-row > th
+     {
+       padding-top: 5px;
+     }
+    </style>
+  </head>
   <body>
     <h1>Your booking request was accepted!</h1>
 
@@ -19,30 +44,31 @@
     <table>
       <thead>
         <tr>
-          <th style="text-align: left;">Payment</th>
+          <td class="left">Start date</td>
+          <td class="right">End date</td>
+        </tr>
+        <tr>
+          <th class="left">{{date booking.start format="EEEE"}}</th>
+          <th class="right">{{date booking.end format="EEEE"}}</th>
+        </tr>
+        <tr class="bottom-row">
+          <th class="left">{{date booking.start format="MMM d"}}</th>
+          <th class="right">{{date booking.end format="MMM d"}}</th>
         </tr>
       </thead>
-      <tbody>
       {{#each tx-line-items}}
         {{#contains include-for "customer"}}
           {{#eq "line-item/night" code}}
-            <tr>
-              <td>Price per night</td>
-              <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
-            </tr>
             {{#if seats}}
-            <tr>
-              <td>Nights</td>
-              <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
+            <tr class="top-row">
+              <td colspan="2">{{> format-money money=unit-price}} &times; {{number units}} {{inflect units "night" "nights"}}</td>
             </tr>
-            <tr>
-              <td>Seats</td>
-              <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
+            <tr class="bottom-row">
+              <td colspan="2">Seats &times; {{number seats}}</td>
             </tr>
             {{else}}
-            <tr>
-              <td>Nights</td>
-              <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
+            <tr class="top-row bottom-row">
+              <td colspan="2">{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "night" "nights"}}</td>
             </tr>
             {{/if}}
           {{/eq}}
@@ -50,9 +76,9 @@
       {{/each}}
       </tbody>
       <tfoot>
-        <tr>
-          <th style="text-align: left;">Payment total</th>
-          <th style="text-align: left; padding-left: 20px;">{{> format-money money=payin-total}}</th>
+        <tr class="top-row">
+          <th class="left">Total price</th>
+          <th class="right">{{> format-money money=payin-total}}</th>
         </tr>
       </tfoot>
     </table>

--- a/preauth-nightly-booking/templates/money-paid/money-paid-html.html
+++ b/preauth-nightly-booking/templates/money-paid/money-paid-html.html
@@ -8,6 +8,31 @@
 {{~/inline~}}
 
 <html>
+  <head>
+    <style type="text/css">
+     table {
+       border-collapse: collapse;
+     }
+     .left {
+       text-align: left;
+     }
+     .right {
+       text-align: right;
+       padding-left: 20px;
+     }
+     .bottom-row > td {
+       padding-bottom: 5px;
+     }
+     .top-row {
+       border-top: 1px solid #CCC;
+     }
+     .top-row > td,
+     .top-row > th
+     {
+       padding-top: 5px;
+     }
+    </style>
+  </head>
   <body>
     {{#with transaction}}
     <h1>You have been paid {{> format-money money=payout-total}}</h1>
@@ -19,51 +44,53 @@
     <table>
       <thead>
         <tr>
-          <th style="text-align: left;">Payment</th>
+          <td class="left">Start date</td>
+          <td class="right">End date</td>
+        </tr>
+        <tr>
+          <th class="left">{{date booking.start format="EEEE"}}</th>
+          <th class="right">{{date booking.end format="EEEE"}}</th>
+        </tr>
+        <tr class="bottom-row">
+          <th class="left">{{date booking.start format="MMM d"}}</th>
+          <th class="right">{{date booking.end format="MMM d"}}</th>
         </tr>
       </thead>
       <tbody>
       {{#each tx-line-items}}
         {{#contains include-for "provider"}}
           {{#eq "line-item/night" code}}
-            <tr>
-              <td>Price per night</td>
-              <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
-            </tr>
             {{#if seats}}
-            <tr>
-              <td>Nights</td>
-              <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
+            <tr class="top-row">
+              <td colspan="2">{{> format-money money=unit-price}} &times; {{number units}} {{inflect units "night" "nights"}}</td>
             </tr>
-            <tr>
-              <td>Seats</td>
-              <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
+            <tr class="bottom-row">
+              <td colspan="2">Seats &times; {{number seats}}</td>
             </tr>
             {{else}}
-            <tr>
-              <td>Nights</td>
-              <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
+            <tr class="top-row bottom-row">
+              <td colspan="2">{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "night" "nights"}}</td>
             </tr>
             {{/if}}
-            <tr>
-              <th style="text-align: left;">Subtotal</th>
-              <th style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</th>
+            <tr class="top-row">
+              <th class="left">Subtotal</th>
+              <th class="right">{{> format-money money=line-total}}</th>
             </tr>
           {{/eq}}
 
           {{#eq "line-item/provider-commission" code}}
-            </tr>
-              <td>{{marketplace.name}} fee:</td>
-              <td style="text-align: right; padding-left: 20px;">{{> format-money money=line-total}}</td>
+            <tr class="bottom-row">
+              <td>{{marketplace.name}} fee</td>
+              <td class="right">{{> format-money money=line-total}}</td>
             </tr>
           {{/eq}}
         {{/contains}}
       {{/each}}
       </tbody>
       <tfoot>
-        <tr>
-          <th style="text-align: left;">You earn</th>
-          <th style="text-align: right; padding-left: 20px;">{{> format-money money=payout-total}}</th>
+        <tr class="top-row">
+          <th class="left">You'll make</th>
+          <th class="right">{{> format-money money=payout-total}}</th>
         </tr>
       </tfoot>
     </table>

--- a/preauth-nightly-booking/templates/new-booking-request/new-booking-request-html.html
+++ b/preauth-nightly-booking/templates/new-booking-request/new-booking-request-html.html
@@ -8,60 +8,86 @@
 {{~/inline~}}
 
 <html>
+  <head>
+    <style type="text/css">
+     table {
+       border-collapse: collapse;
+     }
+     .left {
+       text-align: left;
+     }
+     .right {
+       text-align: right;
+       padding-left: 20px;
+     }
+     .bottom-row > td {
+       padding-bottom: 5px;
+     }
+     .top-row {
+       border-top: 1px solid #CCC;
+     }
+     .top-row > td,
+     .top-row > th
+     {
+       padding-top: 5px;
+     }
+    </style>
+  </head>
   <body>
     {{#with transaction}}
     <h1>Please respond to a request by {{customer.display-name}}</h1>
 
     <p>Good news! {{customer.display-name}} just requested to book {{listing.title}} from {{> format-date date=booking.start}} to {{> format-date date=booking.end}}. Here's the breakdown.</p>
-
     <table>
       <thead>
         <tr>
-          <th style="text-align: left;">Payment</th>
+          <td class="left">Start date</td>
+          <td class="right">End date</td>
+        </tr>
+        <tr>
+          <th class="left">{{date booking.start format="EEEE"}}</th>
+          <th class="right">{{date booking.end format="EEEE"}}</th>
+        </tr>
+        <tr class="bottom-row">
+          <th class="left">{{date booking.start format="MMM d"}}</th>
+          <th class="right">{{date booking.end format="MMM d"}}</th>
         </tr>
       </thead>
       <tbody>
       {{#each tx-line-items}}
         {{#contains include-for "provider"}}
           {{#eq "line-item/night" code}}
-            <tr>
-              <td>Price per night</td>
-              <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
-            </tr>
             {{#if seats}}
-            <tr>
-              <td>Nights</td>
-              <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
+            <tr class="top-row">
+              <td colspan="2">{{> format-money money=unit-price}} &times; {{number units}} {{inflect units "night" "nights"}}</td>
             </tr>
-            <tr>
-              <td>Seats</td>
-              <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
+            <tr class="bottom-row">
+              <td colspan="2">Seats &times; {{number seats}}</td>
             </tr>
             {{else}}
-            <tr>
-              <td>Nights</td>
-              <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
+            <tr class="top-row bottom-row">
+              <td colspan="2">{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "night" "nights"}}</td>
             </tr>
             {{/if}}
-            <tr>
-              <th style="text-align: left;">Subtotal</th>
-              <th style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</th>
+            <tr class="top-row">
+              <th class="left">Subtotal</th>
+              <th class="right">{{> format-money money=line-total}}</th>
             </tr>
           {{/eq}}
 
           {{#eq "line-item/provider-commission" code}}
-            <tr>
+            <tr class="bottom-row">
               <td>{{marketplace.name}} fee</td>
-              <td style="text-align: right; padding-left: 20px;">{{> format-money money=line-total}}</td>
+              <td class="right">{{> format-money money=line-total}}</td>
             </tr>
           {{/eq}}
         {{/contains}}
       {{/each}}
       </tbody>
       <tfoot>
-        <tr>
-          <th style="text-align: left;">You earn</th>
-          <th style="text-align: left; padding-left: 20px;">{{> format-money money=payout-total}}</th>
+        <tr class="top-row">
+          <th class="left">You'll make</th>
+          <th class="right">{{> format-money money=payout-total}}</th>
         </tr>
       </tfoot>
     </table>

--- a/preauth-unit-booking/templates/booking-request-accepted/booking-request-accepted-html.html
+++ b/preauth-unit-booking/templates/booking-request-accepted/booking-request-accepted-html.html
@@ -8,6 +8,31 @@
 {{~/inline~}}
 
 <html>
+  <head>
+    <style type="text/css">
+     table {
+       border-collapse: collapse;
+     }
+     .left {
+       text-align: left;
+     }
+     .right {
+       text-align: right;
+       padding-left: 20px;
+     }
+     .bottom-row > td {
+       padding-bottom: 5px;
+     }
+     .top-row {
+       border-top: 1px solid #CCC;
+     }
+     .top-row > td,
+     .top-row > th
+     {
+       padding-top: 5px;
+     }
+    </style>
+  </head>
   <body>
     <h1>Your booking request was accepted!</h1>
 
@@ -19,40 +44,42 @@
     <table>
       <thead>
         <tr>
-          <th style="text-align: left;">Payment</th>
+          <td class="left">Start date</td>
+          <td class="right">End date</td>
+        </tr>
+        <tr>
+          <th class="left">{{date booking.start format="EEEE"}}</th>
+          <th class="right">{{date booking.end format="EEEE"}}</th>
+        </tr>
+        <tr class="bottom-row">
+          <th class="left">{{date booking.start format="MMM d"}}</th>
+          <th class="right">{{date booking.end format="MMM d"}}</th>
         </tr>
       </thead>
       <tbody>
       {{#each tx-line-items}}
         {{#contains include-for "customer"}}
           {{#eq "line-item/units" code}}
-              <tr>
-                <td>Price per unit</td>
-                <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
-              </tr>
-              {{#if seats}}
-              <tr>
-                <td>Units</td>
-                <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
-              </tr>
-              <tr>
-                <td>Seats</td>
-                <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
-              </tr>
-              {{else}}
-              <tr>
-                <td>Units</td>
-                <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
-              </tr>
-              {{/if}}
+            {{#if seats}}
+            <tr class="top-row">
+              <td colspan="2">{{> format-money money=unit-price}} &times; {{number units}} {{inflect units "unit" "units"}}</td>
+            </tr>
+            <tr class="bottom-row">
+              <td colspan="2">Seats &times; {{number seats}}</td>
+            </tr>
+            {{else}}
+            <tr class="top-row bottom-row">
+              <td colspan="2">{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "unit" "units"}}</td>
+            </tr>
+            {{/if}}
           {{/eq}}
         {{/contains}}
       {{/each}}
       </tbody>
       <tfoot>
-        <tr>
-          <th style="text-align: left;">Payment total</th>
-          <th style="text-align: left; padding-left: 20px;">{{> format-money money=payin-total}}</th>
+        <tr class="top-row">
+          <th class="left">Total price</th>
+          <th class="right">{{> format-money money=payin-total}}</th>
         </tr>
       </tfoot>
     </table>

--- a/preauth-unit-booking/templates/money-paid/money-paid-html.html
+++ b/preauth-unit-booking/templates/money-paid/money-paid-html.html
@@ -8,6 +8,31 @@
 {{~/inline~}}
 
 <html>
+  <head>
+    <style type="text/css">
+     table {
+       border-collapse: collapse;
+     }
+     .left {
+       text-align: left;
+     }
+     .right {
+       text-align: right;
+       padding-left: 20px;
+     }
+     .bottom-row > td {
+       padding-bottom: 5px;
+     }
+     .top-row {
+       border-top: 1px solid #CCC;
+     }
+     .top-row > td,
+     .top-row > th
+     {
+       padding-top: 5px;
+     }
+    </style>
+  </head>
   <body>
     {{#with transaction}}
     <h1>You have been paid {{> format-money money=payout-total}}</h1>
@@ -19,51 +44,53 @@
     <table>
       <thead>
         <tr>
-          <th style="text-align: left;">Payment</th>
+          <td class="left">Start date</td>
+          <td class="right">End date</td>
+        </tr>
+        <tr>
+          <th class="left">{{date booking.start format="EEEE"}}</th>
+          <th class="right">{{date booking.end format="EEEE"}}</th>
+        </tr>
+        <tr class="bottom-row">
+          <th class="left">{{date booking.start format="MMM d"}}</th>
+          <th class="right">{{date booking.end format="MMM d"}}</th>
         </tr>
       </thead>
       <tbody>
       {{#each tx-line-items}}
         {{#contains include-for "provider"}}
           {{#eq "line-item/units" code}}
-            <tr>
-              <td>Price per unit</td>
-              <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
-            </tr>
             {{#if seats}}
-            <tr>
-              <td>Units</td>
-              <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
+            <tr class="top-row">
+              <td colspan="2">{{> format-money money=unit-price}} &times; {{number units}} {{inflect units "unit" "units"}}</td>
             </tr>
-            <tr>
-              <td>Seats</td>
-              <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
+            <tr class="bottom-row">
+              <td colspan="2">Seats &times; {{number seats}}</td>
             </tr>
             {{else}}
-            <tr>
-              <td>Units</td>
-              <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
+            <tr class="top-row bottom-row">
+              <td colspan="2">{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "unit" "units"}}</td>
             </tr>
             {{/if}}
-            <tr>
-              <th style="text-align: left;">Subtotal</th>
-              <th style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</th>
+            <tr class="top-row">
+              <th class="left">Subtotal</th>
+              <th class="right">{{> format-money money=line-total}}</th>
             </tr>
           {{/eq}}
 
           {{#eq "line-item/provider-commission" code}}
-            </tr>
-              <td>{{marketplace.name}} fee:</td>
-              <td style="text-align: right; padding-left: 20px;">{{> format-money money=line-total}}</td>
+            <tr class="bottom-row">
+              <td>{{marketplace.name}} fee</td>
+              <td class="right">{{> format-money money=line-total}}</td>
             </tr>
           {{/eq}}
         {{/contains}}
       {{/each}}
       </tbody>
       <tfoot>
-        <tr>
-          <th style="text-align: left;">You earn</th>
-          <th style="text-align: right; padding-left: 20px;">{{> format-money money=payout-total}}</th>
+        <tr class="top-row">
+          <th class="left">You'll make</th>
+          <th class="right">{{> format-money money=payout-total}}</th>
         </tr>
       </tfoot>
     </table>

--- a/preauth-unit-booking/templates/new-booking-request/new-booking-request-html.html
+++ b/preauth-unit-booking/templates/new-booking-request/new-booking-request-html.html
@@ -8,6 +8,31 @@
 {{~/inline~}}
 
 <html>
+  <head>
+    <style type="text/css">
+     table {
+       border-collapse: collapse;
+     }
+     .left {
+       text-align: left;
+     }
+     .right {
+       text-align: right;
+       padding-left: 20px;
+     }
+     .bottom-row > td {
+       padding-bottom: 5px;
+     }
+     .top-row {
+       border-top: 1px solid #CCC;
+     }
+     .top-row > td,
+     .top-row > th
+     {
+       padding-top: 5px;
+     }
+    </style>
+  </head>
   <body>
     {{#with transaction}}
     <h1>Please respond to a request by {{customer.display-name}}</h1>
@@ -17,51 +42,53 @@
     <table>
       <thead>
         <tr>
-          <th style="text-align: left;">Payment</th>
+          <td class="left">Start date</td>
+          <td class="right">End date</td>
+        </tr>
+        <tr>
+          <th class="left">{{date booking.start format="EEEE"}}</th>
+          <th class="right">{{date booking.end format="EEEE"}}</th>
+        </tr>
+        <tr class="bottom-row">
+          <th class="left">{{date booking.start format="MMM d"}}</th>
+          <th class="right">{{date booking.end format="MMM d"}}</th>
         </tr>
       </thead>
       <tbody>
       {{#each tx-line-items}}
         {{#contains include-for "provider"}}
           {{#eq "line-item/units" code}}
-            <tr>
-              <td>Price per unit</td>
-              <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
-            </tr>
             {{#if seats}}
-            <tr>
-              <td>Units</td>
-              <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
+            <tr class="top-row">
+              <td colspan="2">{{> format-money money=unit-price}} &times; {{number units}} {{inflect units "unit" "units"}}</td>
             </tr>
-            <tr>
-              <td>Seats</td>
-              <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
+            <tr class="bottom-row">
+              <td colspan="2">Seats &times; {{number seats}}</td>
             </tr>
             {{else}}
-            <tr>
-              <td>Units</td>
-              <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
+            <tr class="top-row bottom-row">
+              <td colspan="2">{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "unit" "units"}}</td>
             </tr>
             {{/if}}
-            <tr>
-              <th style="text-align: left;">Subtotal</th>
-              <th style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</th>
+            <tr class="top-row">
+              <th class="left">Subtotal</th>
+              <th class="right">{{> format-money money=line-total}}</th>
             </tr>
           {{/eq}}
 
           {{#eq "line-item/provider-commission" code}}
-            <tr>
+            <tr class="bottom-row">
               <td>{{marketplace.name}} fee</td>
-              <td style="text-align: right; padding-left: 20px;">{{> format-money money=line-total}}</td>
+              <td class="right">{{> format-money money=line-total}}</td>
             </tr>
           {{/eq}}
         {{/contains}}
       {{/each}}
       </tbody>
       <tfoot>
-        <tr>
-          <th style="text-align: left;">You earn</th>
-          <th style="text-align: left; padding-left: 20px;">{{> format-money money=payout-total}}</th>
+        <tr class="top-row">
+          <th class="left">You'll make</th>
+          <th class="right">{{> format-money money=payout-total}}</th>
         </tr>
       </tfoot>
     </table>

--- a/preauth-unit-time-booking/templates/booking-request-accepted/booking-request-accepted-html.html
+++ b/preauth-unit-time-booking/templates/booking-request-accepted/booking-request-accepted-html.html
@@ -4,10 +4,35 @@
 {{~/inline~}}
 
 {{~#*inline "format-date"~}}
-{{date date format="MMM d, YYYY"}}
+{{date date format="hh:mm a"}} on {{date date format="MMM d, YYYY"}}
 {{~/inline~}}
 
 <html>
+  <head>
+    <style type="text/css">
+     table {
+       border-collapse: collapse;
+     }
+     .left {
+       text-align: left;
+     }
+     .right {
+       text-align: right;
+       padding-left: 20px;
+     }
+     .bottom-row > td {
+       padding-bottom: 5px;
+     }
+     .top-row {
+       border-top: 1px solid #CCC;
+     }
+     .top-row > td,
+     .top-row > th
+     {
+       padding-top: 5px;
+     }
+    </style>
+  </head>
   <body>
     <h1>Your booking request was accepted!</h1>
 
@@ -19,40 +44,42 @@
     <table>
       <thead>
         <tr>
-          <th style="text-align: left;">Payment</th>
+          <td class="left">Start date</td>
+          <td class="right">End date</td>
+        </tr>
+        <tr>
+            <th class="left">{{date booking.start format="EE hh:mm a"}}</th>
+            <th class="right">{{date booking.end format="EE hh:mm a"}}</th>
+        </tr>
+        <tr class="bottom-row">
+          <th class="left">{{date booking.start format="MMM d"}}</th>
+          <th class="right">{{date booking.end format="MMM d"}}</th>
         </tr>
       </thead>
       <tbody>
       {{#each tx-line-items}}
         {{#contains include-for "customer"}}
           {{#eq "line-item/units" code}}
-              <tr>
-                <td>Price per unit</td>
-                <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
-              </tr>
-              {{#if seats}}
-              <tr>
-                <td>Units</td>
-                <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
-              </tr>
-              <tr>
-                <td>Seats</td>
-                <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
-              </tr>
-              {{else}}
-              <tr>
-                <td>Units</td>
-                <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
-              </tr>
-              {{/if}}
+            {{#if seats}}
+            <tr class="top-row">
+              <td colspan="2">{{> format-money money=unit-price}} &times; {{number units}} {{inflect units "unit" "units"}}</td>
+            </tr>
+            <tr class="bottom-row">
+              <td colspan="2">Seats &times; {{number seats}}</td>
+            </tr>
+            {{else}}
+            <tr class="top-row bottom-row">
+              <td colspan="2">{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "unit" "units"}}</td>
+            </tr>
+            {{/if}}
           {{/eq}}
         {{/contains}}
       {{/each}}
       </tbody>
       <tfoot>
-        <tr>
-          <th style="text-align: left;">Payment total</th>
-          <th style="text-align: left; padding-left: 20px;">{{> format-money money=payin-total}}</th>
+        <tr class="top-row">
+          <th class="left">Total price</th>
+          <th class="right">{{> format-money money=payin-total}}</th>
         </tr>
       </tfoot>
     </table>

--- a/preauth-unit-time-booking/templates/money-paid/money-paid-html.html
+++ b/preauth-unit-time-booking/templates/money-paid/money-paid-html.html
@@ -4,10 +4,35 @@
 {{~/inline~}}
 
 {{~#*inline "format-date"~}}
-{{date date format="MMM d, YYYY"}}
+{{date date format="hh:mm a"}} on {{date date format="MMM d, YYYY"}}
 {{~/inline~}}
 
 <html>
+  <head>
+    <style type="text/css">
+     table {
+       border-collapse: collapse;
+     }
+     .left {
+       text-align: left;
+     }
+     .right {
+       text-align: right;
+       padding-left: 20px;
+     }
+     .bottom-row > td {
+       padding-bottom: 5px;
+     }
+     .top-row {
+       border-top: 1px solid #CCC;
+     }
+     .top-row > td,
+     .top-row > th
+     {
+       padding-top: 5px;
+     }
+    </style>
+  </head>
   <body>
     {{#with transaction}}
     <h1>You have been paid {{> format-money money=payout-total}}</h1>
@@ -19,51 +44,53 @@
     <table>
       <thead>
         <tr>
-          <th style="text-align: left;">Payment</th>
+          <td class="left">Start date</td>
+          <td class="right">End date</td>
+        </tr>
+        <tr>
+          <th class="left">{{date booking.start format="EE hh:mm a"}}</th>
+          <th class="right">{{date booking.end format="EE hh:mm a"}}</th>
+        </tr>
+        <tr class="bottom-row">
+          <th class="left">{{date booking.start format="MMM d"}}</th>
+          <th class="right">{{date booking.end format="MMM d"}}</th>
         </tr>
       </thead>
       <tbody>
       {{#each tx-line-items}}
         {{#contains include-for "provider"}}
           {{#eq "line-item/units" code}}
-            <tr>
-              <td>Price per unit</td>
-              <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
-            </tr>
             {{#if seats}}
-            <tr>
-              <td>Units</td>
-              <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
+            <tr class="top-row">
+              <td colspan="2">{{> format-money money=unit-price}} &times; {{number units}} {{inflect units "unit" "units"}}</td>
             </tr>
-            <tr>
-              <td>Seats</td>
-              <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
+            <tr class="bottom-row">
+              <td colspan="2">Seats &times; {{number seats}}</td>
             </tr>
             {{else}}
-            <tr>
-              <td>Units</td>
-              <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
+            <tr class="top-row bottom-row">
+              <td colspan="2">{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "unit" "units"}}</td>
             </tr>
             {{/if}}
-            <tr>
-              <th style="text-align: left;">Subtotal</th>
-              <th style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</th>
+            <tr class="top-row">
+              <th class="left">Subtotal</th>
+              <th class="right">{{> format-money money=line-total}}</th>
             </tr>
           {{/eq}}
 
           {{#eq "line-item/provider-commission" code}}
-            </tr>
-              <td>{{marketplace.name}} fee:</td>
-              <td style="text-align: right; padding-left: 20px;">{{> format-money money=line-total}}</td>
+            <tr class="bottom-row">
+              <td>{{marketplace.name}} fee</td>
+              <td class="right">{{> format-money money=line-total}}</td>
             </tr>
           {{/eq}}
         {{/contains}}
       {{/each}}
       </tbody>
       <tfoot>
-        <tr>
-          <th style="text-align: left;">You earn</th>
-          <th style="text-align: right; padding-left: 20px;">{{> format-money money=payout-total}}</th>
+        <tr class="top-row">
+          <th class="left">You'll make</th>
+          <th class="right">{{> format-money money=payout-total}}</th>
         </tr>
       </tfoot>
     </table>

--- a/preauth-unit-time-booking/templates/new-booking-request/new-booking-request-html.html
+++ b/preauth-unit-time-booking/templates/new-booking-request/new-booking-request-html.html
@@ -4,10 +4,35 @@
 {{~/inline~}}
 
 {{~#*inline "format-date"~}}
-{{date date format="MMM d, YYYY"}}
+{{date date format="hh:mm a"}} on {{date date format="MMM d, YYYY"}}
 {{~/inline~}}
 
 <html>
+  <head>
+    <style type="text/css">
+     table {
+       border-collapse: collapse;
+     }
+     .left {
+       text-align: left;
+     }
+     .right {
+       text-align: right;
+       padding-left: 20px;
+     }
+     .bottom-row > td {
+       padding-bottom: 5px;
+     }
+     .top-row {
+       border-top: 1px solid #CCC;
+     }
+     .top-row > td,
+     .top-row > th
+     {
+       padding-top: 5px;
+     }
+    </style>
+  </head>
   <body>
     {{#with transaction}}
     <h1>Please respond to a request by {{customer.display-name}}</h1>
@@ -17,51 +42,53 @@
     <table>
       <thead>
         <tr>
-          <th style="text-align: left;">Payment</th>
+          <td class="left">Start date</td>
+          <td class="right">End date</td>
+        </tr>
+        <tr>
+          <th class="left">{{date booking.start format="EE hh:mm a"}}</th>
+          <th class="right">{{date booking.end format="EE hh:mm a"}}</th>
+        </tr>
+        <tr class="bottom-row">
+          <th class="left">{{date booking.start format="MMM d"}}</th>
+          <th class="right">{{date booking.end format="MMM d"}}</th>
         </tr>
       </thead>
       <tbody>
       {{#each tx-line-items}}
         {{#contains include-for "provider"}}
           {{#eq "line-item/units" code}}
-            <tr>
-              <td>Price per unit</td>
-              <td style="text-align: right; padding-left: 20px">{{> format-money money=unit-price}}</td>
-            </tr>
             {{#if seats}}
-            <tr>
-              <td>Units</td>
-              <td style="text-align: right; padding-left: 20px">&times; {{number units}}</td>
+            <tr class="top-row">
+              <td colspan="2">{{> format-money money=unit-price}} &times; {{number units}} {{inflect units "unit" "units"}}</td>
             </tr>
-            <tr>
-              <td>Seats</td>
-              <td style="text-align: right; padding-left: 20px">&times; {{number seats}}</td>
+            <tr class="bottom-row">
+              <td colspan="2">Seats &times; {{number seats}}</td>
             </tr>
             {{else}}
-            <tr>
-              <td>Units</td>
-              <td style="text-align: right; padding-left: 20px">&times; {{number quantity}}</td>
+            <tr class="top-row bottom-row">
+              <td colspan="2">{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "unit" "units"}}</td>
             </tr>
             {{/if}}
-            <tr>
-              <th style="text-align: left;">Subtotal</th>
-              <th style="text-align: right; padding-left: 20px">{{> format-money money=line-total}}</th>
+            <tr class="top-row">
+              <th class="left">Subtotal</th>
+              <th class="right">{{> format-money money=line-total}}</th>
             </tr>
           {{/eq}}
 
           {{#eq "line-item/provider-commission" code}}
-            <tr>
+            <tr class="bottom-row">
               <td>{{marketplace.name}} fee</td>
-              <td style="text-align: right; padding-left: 20px;">{{> format-money money=line-total}}</td>
+              <td class="right">{{> format-money money=line-total}}</td>
             </tr>
           {{/eq}}
         {{/contains}}
       {{/each}}
       </tbody>
       <tfoot>
-        <tr>
-          <th style="text-align: left;">You earn</th>
-          <th style="text-align: left; padding-left: 20px;">{{> format-money money=payout-total}}</th>
+        <tr class="top-row">
+          <th class="left">You'll make</th>
+          <th class="right">{{> format-money money=payout-total}}</th>
         </tr>
       </tfoot>
     </table>


### PR DESCRIPTION
Updates the booking breakdown in tx email templates. Now a booking breakdown renders as follows with a nightly process and seats in Gmail client:

![Screenshot 2019-10-17 at 8 01 05](https://user-images.githubusercontent.com/57473/66978977-9bca0b80-f0b4-11e9-95c3-3452065654f3.png)

Also improves date formatting for time-based units booking process.