### PR TITLE
Add timezone parameter to dates in email templates

### DIFF
--- a/negotiated-nightly-booking/templates/counter-offer/counter-offer-html.html
+++ b/negotiated-nightly-booking/templates/counter-offer/counter-offer-html.html
@@ -4,7 +4,7 @@
 {{~/inline~}}
 
 {{~#*inline "format-date"~}}
-{{date date format="MMM d, YYYY"}}
+{{date date format="MMM d, YYYY" tz="Etc/UTC"}}
 {{~/inline~}}
 
 <html>
@@ -50,12 +50,12 @@
           <td class="right">End date</td>
         </tr>
         <tr>
-          <th class="left">{{date booking.start format="EEEE"}}</th>
-          <th class="right">{{date booking.end format="EEEE"}}</th>
+          <th class="left">{{date booking.start format="EEEE" tz="Etc/UTC"}}</th>
+          <th class="right">{{date booking.end format="EEEE" tz="Etc/UTC"}}</th>
         </tr>
         <tr class="bottom-row">
-          <th class="left">{{date booking.start format="MMM d"}}</th>
-          <th class="right">{{date booking.end format="MMM d"}}</th>
+          <th class="left">{{date booking.start format="MMM d" tz="Etc/UTC"}}</th>
+          <th class="right">{{date booking.end format="MMM d" tz="Etc/UTC"}}</th>
         </tr>
       </thead>
       <tbody>

--- a/negotiated-nightly-booking/templates/customer-paid/customer-paid-html.html
+++ b/negotiated-nightly-booking/templates/customer-paid/customer-paid-html.html
@@ -4,7 +4,7 @@
 {{~/inline~}}
 
 {{~#*inline "format-date"~}}
-{{date date format="MMM d, YYYY"}}
+{{date date format="MMM d, YYYY" tz="Etc/UTC"}}
 {{~/inline~}}
 
 <html>
@@ -46,12 +46,12 @@
           <td class="right">End date</td>
         </tr>
         <tr>
-          <th class="left">{{date booking.start format="EEEE"}}</th>
-          <th class="right">{{date booking.end format="EEEE"}}</th>
+          <th class="left">{{date booking.start format="EEEE" tz="Etc/UTC"}}</th>
+          <th class="right">{{date booking.end format="EEEE" tz="Etc/UTC"}}</th>
         </tr>
         <tr class="bottom-row">
-          <th class="left">{{date booking.start format="MMM d"}}</th>
-          <th class="right">{{date booking.end format="MMM d"}}</th>
+          <th class="left">{{date booking.start format="MMM d" tz="Etc/UTC"}}</th>
+          <th class="right">{{date booking.end format="MMM d" tz="Etc/UTC"}}</th>
         </tr>
       </thead>
       <tbody>

--- a/negotiated-nightly-booking/templates/money-paid/money-paid-html.html
+++ b/negotiated-nightly-booking/templates/money-paid/money-paid-html.html
@@ -4,7 +4,7 @@
 {{~/inline~}}
 
 {{~#*inline "format-date"~}}
-{{date date format="MMM d, YYYY"}}
+{{date date format="MMM d, YYYY" tz="Etc/UTC"}}
 {{~/inline~}}
 
 <html>
@@ -48,12 +48,12 @@
           <td class="right">End date</td>
         </tr>
         <tr>
-          <th class="left">{{date booking.start format="EEEE"}}</th>
-          <th class="right">{{date booking.end format="EEEE"}}</th>
+          <th class="left">{{date booking.start format="EEEE" tz="Etc/UTC"}}</th>
+          <th class="right">{{date booking.end format="EEEE" tz="Etc/UTC"}}</th>
         </tr>
         <tr class="bottom-row">
-          <th class="left">{{date booking.start format="MMM d"}}</th>
-          <th class="right">{{date booking.end format="MMM d"}}</th>
+          <th class="left">{{date booking.start format="MMM d" tz="Etc/UTC"}}</th>
+          <th class="right">{{date booking.end format="MMM d" tz="Etc/UTC"}}</th>
         </tr>
       </thead>
       <tbody>

--- a/negotiated-nightly-booking/templates/new-booking-request-with-offer/new-booking-request-with-offer-html.html
+++ b/negotiated-nightly-booking/templates/new-booking-request-with-offer/new-booking-request-with-offer-html.html
@@ -4,7 +4,7 @@
 {{~/inline~}}
 
 {{~#*inline "format-date"~}}
-{{date date format="MMM d, YYYY"}}
+{{date date format="MMM d, YYYY" tz="Etc/UTC"}}
 {{~/inline~}}
 
 <html>
@@ -46,12 +46,12 @@
           <td class="right">End date</td>
         </tr>
         <tr>
-          <th class="left">{{date booking.start format="EEEE"}}</th>
-          <th class="right">{{date booking.end format="EEEE"}}</th>
+          <th class="left">{{date booking.start format="EEEE" tz="Etc/UTC"}}</th>
+          <th class="right">{{date booking.end format="EEEE" tz="Etc/UTC"}}</th>
         </tr>
         <tr class="bottom-row">
-          <th class="left">{{date booking.start format="MMM d"}}</th>
-          <th class="right">{{date booking.end format="MMM d"}}</th>
+          <th class="left">{{date booking.start format="MMM d" tz="Etc/UTC"}}</th>
+          <th class="right">{{date booking.end format="MMM d" tz="Etc/UTC"}}</th>
         </tr>
       </thead>
       <tbody>

--- a/negotiated-nightly-booking/templates/offer-declined/offer-declined-html.html
+++ b/negotiated-nightly-booking/templates/offer-declined/offer-declined-html.html
@@ -1,6 +1,6 @@
 
 {{~#*inline "format-date"~}}
-{{date date format="MMM d, YYYY"}}
+{{date date format="MMM d, YYYY" tz="Etc/UTC"}}
 {{~/inline~}}
 
 <html>

--- a/negotiated-nightly-booking/templates/offer-expired/offer-expired-html.html
+++ b/negotiated-nightly-booking/templates/offer-expired/offer-expired-html.html
@@ -1,6 +1,6 @@
 
 {{~#*inline "format-date"~}}
-{{date date format="MMM d, YYYY"}}
+{{date date format="MMM d, YYYY" tz="Etc/UTC"}}
 {{~/inline~}}
 
 <html>

--- a/negotiated-nightly-booking/templates/payment-expired/payment-expired-html.html
+++ b/negotiated-nightly-booking/templates/payment-expired/payment-expired-html.html
@@ -1,6 +1,6 @@
 
 {{~#*inline "format-date"~}}
-{{date date format="MMM d, YYYY"}}
+{{date date format="MMM d, YYYY" tz="Etc/UTC"}}
 {{~/inline~}}
 
 <html>

--- a/negotiated-nightly-booking/templates/provider-accepted-offer/provider-accepted-offer-html.html
+++ b/negotiated-nightly-booking/templates/provider-accepted-offer/provider-accepted-offer-html.html
@@ -4,7 +4,7 @@
 {{~/inline~}}
 
 {{~#*inline "format-date"~}}
-{{date date format="MMM d, YYYY"}}
+{{date date format="MMM d, YYYY" tz="Etc/UTC"}}
 {{~/inline~}}
 
 <html>
@@ -46,12 +46,12 @@
           <td class="right">End date</td>
         </tr>
         <tr>
-          <th class="left">{{date booking.start format="EEEE"}}</th>
-          <th class="right">{{date booking.end format="EEEE"}}</th>
+          <th class="left">{{date booking.start format="EEEE" tz="Etc/UTC"}}</th>
+          <th class="right">{{date booking.end format="EEEE" tz="Etc/UTC"}}</th>
         </tr>
         <tr class="bottom-row">
-          <th class="left">{{date booking.start format="MMM d"}}</th>
-          <th class="right">{{date booking.end format="MMM d"}}</th>
+          <th class="left">{{date booking.start format="MMM d" tz="Etc/UTC"}}</th>
+          <th class="right">{{date booking.end format="MMM d" tz="Etc/UTC"}}</th>
         </tr>
       </thead>
       <tbody>

--- a/preauth-daily-booking/templates/booking-request-accepted/booking-request-accepted-html.html
+++ b/preauth-daily-booking/templates/booking-request-accepted/booking-request-accepted-html.html
@@ -4,11 +4,11 @@
 {{~/inline~}}
 
 {{~#*inline "format-date"~}}
-{{date date format="MMM d, YYYY"}}
+{{date date format="MMM d, YYYY" tz="Etc/UTC"}}
 {{~/inline~}}
 
 {{~#*inline "format-date-day-before"~}}
-{{date-day-before date format="MMM d, YYYY"}}
+{{date-day-before date format="MMM d, YYYY" tz="Etc/UTC"}}
 {{~/inline~}}
 
 <html>
@@ -52,12 +52,12 @@
           <td class="right">End date</td>
         </tr>
         <tr>
-          <th class="left">{{date booking.start format="EEEE"}}</th>
-          <th class="right">{{date-day-before booking.end format="EEEE"}}</th>
+          <th class="left">{{date booking.start format="EEEE" tz="Etc/UTC"}}</th>
+          <th class="right">{{date-day-before booking.end format="EEEE" tz="Etc/UTC"}}</th>
         </tr>
         <tr class="bottom-row">
-          <th class="left">{{date booking.start format="MMM d"}}</th>
-          <th class="right">{{date-day-before booking.end format="MMM d"}}</th>
+          <th class="left">{{date booking.start format="MMM d" tz="Etc/UTC"}}</th>
+          <th class="right">{{date-day-before booking.end format="MMM d" tz="Etc/UTC"}}</th>
         </tr>
       </thead>
       <tbody>

--- a/preauth-daily-booking/templates/booking-request-auto-declined/booking-request-auto-declined-html.html
+++ b/preauth-daily-booking/templates/booking-request-auto-declined/booking-request-auto-declined-html.html
@@ -1,10 +1,10 @@
 
 {{~#*inline "format-date"~}}
-{{date date format="MMM d, YYYY"}}
+{{date date format="MMM d, YYYY" tz="Etc/UTC"}}
 {{~/inline~}}
 
 {{~#*inline "format-date-day-before"~}}
-{{date-day-before date format="MMM d, YYYY"}}
+{{date-day-before date format="MMM d, YYYY" tz="Etc/UTC"}}
 {{~/inline~}}
 
 <html>

--- a/preauth-daily-booking/templates/booking-request-declined/booking-request-declined-html.html
+++ b/preauth-daily-booking/templates/booking-request-declined/booking-request-declined-html.html
@@ -1,10 +1,10 @@
 
 {{~#*inline "format-date"~}}
-{{date date format="MMM d, YYYY"}}
+{{date date format="MMM d, YYYY" tz="Etc/UTC"}}
 {{~/inline~}}
 
 {{~#*inline "format-date-day-before"~}}
-{{date-day-before date format="MMM d, YYYY"}}
+{{date-day-before date format="MMM d, YYYY" tz="Etc/UTC"}}
 {{~/inline~}}
 
 <html>

--- a/preauth-daily-booking/templates/money-paid/money-paid-html.html
+++ b/preauth-daily-booking/templates/money-paid/money-paid-html.html
@@ -4,11 +4,11 @@
 {{~/inline~}}
 
 {{~#*inline "format-date"~}}
-{{date date format="MMM d, YYYY"}}
+{{date date format="MMM d, YYYY" tz="Etc/UTC"}}
 {{~/inline~}}
 
 {{~#*inline "format-date-day-before"~}}
-{{date-day-before date format="MMM d, YYYY"}}
+{{date-day-before date format="MMM d, YYYY" tz="Etc/UTC"}}
 {{~/inline~}}
 
 <html>
@@ -52,12 +52,12 @@
           <td class="right">End date</td>
         </tr>
         <tr>
-          <th class="left">{{date booking.start format="EEEE"}}</th>
-          <th class="right">{{date-day-before booking.end format="EEEE"}}</th>
+          <th class="left">{{date booking.start format="EEEE" tz="Etc/UTC"}}</th>
+          <th class="right">{{date-day-before booking.end format="EEEE" tz="Etc/UTC"}}</th>
         </tr>
         <tr class="bottom-row">
-          <th class="left">{{date booking.start format="MMM d"}}</th>
-          <th class="right">{{date-day-before booking.end format="MMM d"}}</th>
+          <th class="left">{{date booking.start format="MMM d" tz="Etc/UTC"}}</th>
+          <th class="right">{{date-day-before booking.end format="MMM d" tz="Etc/UTC"}}</th>
         </tr>
       </thead>
       <tbody>

--- a/preauth-daily-booking/templates/new-booking-request/new-booking-request-html.html
+++ b/preauth-daily-booking/templates/new-booking-request/new-booking-request-html.html
@@ -4,11 +4,11 @@
 {{~/inline~}}
 
 {{~#*inline "format-date"~}}
-{{date date format="MMM d, YYYY"}}
+{{date date format="MMM d, YYYY" tz="Etc/UTC"}}
 {{~/inline~}}
 
 {{~#*inline "format-date-day-before"~}}
-{{date-day-before date format="MMM d, YYYY"}}
+{{date-day-before date format="MMM d, YYYY" tz="Etc/UTC"}}
 {{~/inline~}}
 
 <html>
@@ -50,12 +50,12 @@
           <td class="right">End date</td>
         </tr>
         <tr>
-          <th class="left">{{date booking.start format="EEEE"}}</th>
-          <th class="right">{{date-day-before booking.end format="EEEE"}}</th>
+          <th class="left">{{date booking.start format="EEEE" tz="Etc/UTC"}}</th>
+          <th class="right">{{date-day-before booking.end format="EEEE" tz="Etc/UTC"}}</th>
         </tr>
         <tr class="bottom-row">
-          <th class="left">{{date booking.start format="MMM d"}}</th>
-          <th class="right">{{date-day-before booking.end format="MMM d"}}</th>
+          <th class="left">{{date booking.start format="MMM d" tz="Etc/UTC"}}</th>
+          <th class="right">{{date-day-before booking.end format="MMM d" tz="Etc/UTC"}}</th>
         </tr>
       </thead>
       <tbody>

--- a/preauth-nightly-booking/templates/booking-request-accepted/booking-request-accepted-html.html
+++ b/preauth-nightly-booking/templates/booking-request-accepted/booking-request-accepted-html.html
@@ -4,7 +4,7 @@
 {{~/inline~}}
 
 {{~#*inline "format-date"~}}
-{{date date format="MMM d, YYYY"}}
+{{date date format="MMM d, YYYY" tz="Etc/UTC"}}
 {{~/inline~}}
 
 <html>
@@ -48,12 +48,12 @@
           <td class="right">End date</td>
         </tr>
         <tr>
-          <th class="left">{{date booking.start format="EEEE"}}</th>
-          <th class="right">{{date booking.end format="EEEE"}}</th>
+          <th class="left">{{date booking.start format="EEEE" tz="Etc/UTC"}}</th>
+          <th class="right">{{date booking.end format="EEEE" tz="Etc/UTC"}}</th>
         </tr>
         <tr class="bottom-row">
-          <th class="left">{{date booking.start format="MMM d"}}</th>
-          <th class="right">{{date booking.end format="MMM d"}}</th>
+          <th class="left">{{date booking.start format="MMM d" tz="Etc/UTC"}}</th>
+          <th class="right">{{date booking.end format="MMM d" tz="Etc/UTC"}}</th>
         </tr>
       </thead>
       {{#each tx-line-items}}

--- a/preauth-nightly-booking/templates/booking-request-auto-declined/booking-request-auto-declined-html.html
+++ b/preauth-nightly-booking/templates/booking-request-auto-declined/booking-request-auto-declined-html.html
@@ -1,6 +1,6 @@
 
 {{~#*inline "format-date"~}}
-{{date date format="MMM d, YYYY"}}
+{{date date format="MMM d, YYYY" tz="Etc/UTC"}}
 {{~/inline~}}
 
 <html>

--- a/preauth-nightly-booking/templates/booking-request-declined/booking-request-declined-html.html
+++ b/preauth-nightly-booking/templates/booking-request-declined/booking-request-declined-html.html
@@ -1,6 +1,6 @@
 
 {{~#*inline "format-date"~}}
-{{date date format="MMM d, YYYY"}}
+{{date date format="MMM d, YYYY" tz="Etc/UTC"}}
 {{~/inline~}}
 
 <html>

--- a/preauth-nightly-booking/templates/money-paid/money-paid-html.html
+++ b/preauth-nightly-booking/templates/money-paid/money-paid-html.html
@@ -4,7 +4,7 @@
 {{~/inline~}}
 
 {{~#*inline "format-date"~}}
-{{date date format="MMM d, YYYY"}}
+{{date date format="MMM d, YYYY" tz="Etc/UTC"}}
 {{~/inline~}}
 
 <html>
@@ -48,12 +48,12 @@
           <td class="right">End date</td>
         </tr>
         <tr>
-          <th class="left">{{date booking.start format="EEEE"}}</th>
-          <th class="right">{{date booking.end format="EEEE"}}</th>
+          <th class="left">{{date booking.start format="EEEE" tz="Etc/UTC"}}</th>
+          <th class="right">{{date booking.end format="EEEE" tz="Etc/UTC"}}</th>
         </tr>
         <tr class="bottom-row">
-          <th class="left">{{date booking.start format="MMM d"}}</th>
-          <th class="right">{{date booking.end format="MMM d"}}</th>
+          <th class="left">{{date booking.start format="MMM d" tz="Etc/UTC"}}</th>
+          <th class="right">{{date booking.end format="MMM d" tz="Etc/UTC"}}</th>
         </tr>
       </thead>
       <tbody>

--- a/preauth-nightly-booking/templates/new-booking-request/new-booking-request-html.html
+++ b/preauth-nightly-booking/templates/new-booking-request/new-booking-request-html.html
@@ -4,7 +4,7 @@
 {{~/inline~}}
 
 {{~#*inline "format-date"~}}
-{{date date format="MMM d, YYYY"}}
+{{date date format="MMM d, YYYY" tz="Etc/UTC"}}
 {{~/inline~}}
 
 <html>
@@ -45,12 +45,12 @@
           <td class="right">End date</td>
         </tr>
         <tr>
-          <th class="left">{{date booking.start format="EEEE"}}</th>
-          <th class="right">{{date booking.end format="EEEE"}}</th>
+          <th class="left">{{date booking.start format="EEEE" tz="Etc/UTC"}}</th>
+          <th class="right">{{date booking.end format="EEEE" tz="Etc/UTC"}}</th>
         </tr>
         <tr class="bottom-row">
-          <th class="left">{{date booking.start format="MMM d"}}</th>
-          <th class="right">{{date booking.end format="MMM d"}}</th>
+          <th class="left">{{date booking.start format="MMM d" tz="Etc/UTC"}}</th>
+          <th class="right">{{date booking.end format="MMM d" tz="Etc/UTC"}}</th>
         </tr>
       </thead>
       <tbody>

--- a/preauth-unit-booking/templates/booking-request-accepted/booking-request-accepted-html.html
+++ b/preauth-unit-booking/templates/booking-request-accepted/booking-request-accepted-html.html
@@ -4,7 +4,7 @@
 {{~/inline~}}
 
 {{~#*inline "format-date"~}}
-{{date date format="MMM d, YYYY"}}
+{{date date format="MMM d, YYYY" tz="Etc/UTC"}}
 {{~/inline~}}
 
 <html>
@@ -48,12 +48,12 @@
           <td class="right">End date</td>
         </tr>
         <tr>
-          <th class="left">{{date booking.start format="EEEE"}}</th>
-          <th class="right">{{date booking.end format="EEEE"}}</th>
+          <th class="left">{{date booking.start format="EEEE" tz="Etc/UTC"}}</th>
+          <th class="right">{{date booking.end format="EEEE" tz="Etc/UTC"}}</th>
         </tr>
         <tr class="bottom-row">
-          <th class="left">{{date booking.start format="MMM d"}}</th>
-          <th class="right">{{date booking.end format="MMM d"}}</th>
+          <th class="left">{{date booking.start format="MMM d" tz="Etc/UTC"}}</th>
+          <th class="right">{{date booking.end format="MMM d" tz="Etc/UTC"}}</th>
         </tr>
       </thead>
       <tbody>

--- a/preauth-unit-booking/templates/booking-request-auto-declined/booking-request-auto-declined-html.html
+++ b/preauth-unit-booking/templates/booking-request-auto-declined/booking-request-auto-declined-html.html
@@ -1,6 +1,6 @@
 
 {{~#*inline "format-date"~}}
-{{date date format="MMM d, YYYY"}}
+{{date date format="MMM d, YYYY" tz="Etc/UTC"}}
 {{~/inline~}}
 
 <html>

--- a/preauth-unit-booking/templates/booking-request-declined/booking-request-declined-html.html
+++ b/preauth-unit-booking/templates/booking-request-declined/booking-request-declined-html.html
@@ -1,6 +1,6 @@
 
 {{~#*inline "format-date"~}}
-{{date date format="MMM d, YYYY"}}
+{{date date format="MMM d, YYYY" tz="Etc/UTC"}}
 {{~/inline~}}
 
 <html>

--- a/preauth-unit-booking/templates/money-paid/money-paid-html.html
+++ b/preauth-unit-booking/templates/money-paid/money-paid-html.html
@@ -4,7 +4,7 @@
 {{~/inline~}}
 
 {{~#*inline "format-date"~}}
-{{date date format="MMM d, YYYY"}}
+{{date date format="MMM d, YYYY" tz="Etc/UTC"}}
 {{~/inline~}}
 
 <html>
@@ -48,12 +48,12 @@
           <td class="right">End date</td>
         </tr>
         <tr>
-          <th class="left">{{date booking.start format="EEEE"}}</th>
-          <th class="right">{{date booking.end format="EEEE"}}</th>
+          <th class="left">{{date booking.start format="EEEE" tz="Etc/UTC"}}</th>
+          <th class="right">{{date booking.end format="EEEE" tz="Etc/UTC"}}</th>
         </tr>
         <tr class="bottom-row">
-          <th class="left">{{date booking.start format="MMM d"}}</th>
-          <th class="right">{{date booking.end format="MMM d"}}</th>
+          <th class="left">{{date booking.start format="MMM d" tz="Etc/UTC"}}</th>
+          <th class="right">{{date booking.end format="MMM d" tz="Etc/UTC"}}</th>
         </tr>
       </thead>
       <tbody>

--- a/preauth-unit-booking/templates/new-booking-request/new-booking-request-html.html
+++ b/preauth-unit-booking/templates/new-booking-request/new-booking-request-html.html
@@ -4,7 +4,7 @@
 {{~/inline~}}
 
 {{~#*inline "format-date"~}}
-{{date date format="MMM d, YYYY"}}
+{{date date format="MMM d, YYYY" tz="Etc/UTC"}}
 {{~/inline~}}
 
 <html>
@@ -46,12 +46,12 @@
           <td class="right">End date</td>
         </tr>
         <tr>
-          <th class="left">{{date booking.start format="EEEE"}}</th>
-          <th class="right">{{date booking.end format="EEEE"}}</th>
+          <th class="left">{{date booking.start format="EEEE" tz="Etc/UTC"}}</th>
+          <th class="right">{{date booking.end format="EEEE" tz="Etc/UTC"}}</th>
         </tr>
         <tr class="bottom-row">
-          <th class="left">{{date booking.start format="MMM d"}}</th>
-          <th class="right">{{date booking.end format="MMM d"}}</th>
+          <th class="left">{{date booking.start format="MMM d" tz="Etc/UTC"}}</th>
+          <th class="right">{{date booking.end format="MMM d" tz="Etc/UTC"}}</th>
         </tr>
       </thead>
       <tbody>

--- a/preauth-unit-time-booking/templates/booking-request-accepted/booking-request-accepted-html.html
+++ b/preauth-unit-time-booking/templates/booking-request-accepted/booking-request-accepted-html.html
@@ -4,7 +4,21 @@
 {{~/inline~}}
 
 {{~#*inline "format-date"~}}
-{{date date format="hh:mm a"}} on {{date date format="MMM d, YYYY"}}
+{{#with transaction.listing.availability-plan}}
+{{date d format="hh:mm a" tz=timezone}} on {{date date format="MMM d, YYYY" tz=timezone}}
+{{/with}}
+{{~/inline~}}
+
+{{~#*inline "format-day-time"~}}
+{{#with transaction.listing.availability-plan}}
+{{date date format="EE hh:mm a" tz=timezone}}
+{{/with}}
+{{~/inline~}}
+
+{{~#*inline "format-month-date"~}}
+{{#with transaction.listing.availability-plan}}
+{{date date format="MMM d" tz=timezone}}
+{{/with}}
 {{~/inline~}}
 
 <html>
@@ -48,12 +62,12 @@
           <td class="right">End date</td>
         </tr>
         <tr>
-            <th class="left">{{date booking.start format="EE hh:mm a"}}</th>
-            <th class="right">{{date booking.end format="EE hh:mm a"}}</th>
+            <th class="left">{{> format-day-time date=booking.start}}</th>
+            <th class="right">{{> format-day-time date=booking.end}}</th>
         </tr>
         <tr class="bottom-row">
-          <th class="left">{{date booking.start format="MMM d"}}</th>
-          <th class="right">{{date booking.end format="MMM d"}}</th>
+          <th class="left">{{> format-month-date date=booking.start format="MMM d"}}</th>
+          <th class="right">{{> format-month-date date=booking.end format="MMM d"}}</th>
         </tr>
       </thead>
       <tbody>

--- a/preauth-unit-time-booking/templates/booking-request-auto-declined/booking-request-auto-declined-html.html
+++ b/preauth-unit-time-booking/templates/booking-request-auto-declined/booking-request-auto-declined-html.html
@@ -1,6 +1,8 @@
 
 {{~#*inline "format-date"~}}
-{{date date format="MMM d, YYYY"}}
+{{#with transaction.listing.availability-plan}}
+{{date d format="hh:mm a" tz=timezone}} on {{date date format="MMM d, YYYY" tz=timezone}}
+{{/with}}
 {{~/inline~}}
 
 <html>

--- a/preauth-unit-time-booking/templates/booking-request-declined/booking-request-declined-html.html
+++ b/preauth-unit-time-booking/templates/booking-request-declined/booking-request-declined-html.html
@@ -1,6 +1,8 @@
 
 {{~#*inline "format-date"~}}
-{{date date format="MMM d, YYYY"}}
+{{#with transaction.listing.availability-plan}}
+{{date d format="hh:mm a" tz=timezone}} on {{date date format="MMM d, YYYY" tz=timezone}}
+{{/with}}
 {{~/inline~}}
 
 <html>

--- a/preauth-unit-time-booking/templates/money-paid/money-paid-html.html
+++ b/preauth-unit-time-booking/templates/money-paid/money-paid-html.html
@@ -4,7 +4,21 @@
 {{~/inline~}}
 
 {{~#*inline "format-date"~}}
-{{date date format="hh:mm a"}} on {{date date format="MMM d, YYYY"}}
+{{#with transaction.listing.availability-plan}}
+{{date d format="hh:mm a" tz=timezone}} on {{date date format="MMM d, YYYY" tz=timezone}}
+{{/with}}
+{{~/inline~}}
+
+{{~#*inline "format-day-time"~}}
+{{#with transaction.listing.availability-plan}}
+{{date date format="EE hh:mm a" tz=timezone}}
+{{/with}}
+{{~/inline~}}
+
+{{~#*inline "format-month-date"~}}
+{{#with transaction.listing.availability-plan}}
+{{date date format="MMM d" tz=timezone}}
+{{/with}}
 {{~/inline~}}
 
 <html>
@@ -48,12 +62,12 @@
           <td class="right">End date</td>
         </tr>
         <tr>
-          <th class="left">{{date booking.start format="EE hh:mm a"}}</th>
-          <th class="right">{{date booking.end format="EE hh:mm a"}}</th>
+          <th class="left">{{> format-day-time date=booking.start}}</th>
+          <th class="right">{{> format-day-time date=booking.end}}</th>
         </tr>
         <tr class="bottom-row">
-          <th class="left">{{date booking.start format="MMM d"}}</th>
-          <th class="right">{{date booking.end format="MMM d"}}</th>
+          <th class="left">{{> format-month-date date=booking.start format="MMM d"}}</th>
+          <th class="right">{{> format-month-date date=booking.end format="MMM d"}}</th>
         </tr>
       </thead>
       <tbody>

--- a/preauth-unit-time-booking/templates/new-booking-request/new-booking-request-html.html
+++ b/preauth-unit-time-booking/templates/new-booking-request/new-booking-request-html.html
@@ -4,7 +4,21 @@
 {{~/inline~}}
 
 {{~#*inline "format-date"~}}
-{{date date format="hh:mm a"}} on {{date date format="MMM d, YYYY"}}
+{{#with transaction.listing.availability-plan}}
+{{date d format="hh:mm a" tz=timezone}} on {{date date format="MMM d, YYYY" tz=timezone}}
+{{/with}}
+{{~/inline~}}
+
+{{~#*inline "format-day-time"~}}
+{{#with transaction.listing.availability-plan}}
+{{date date format="EE hh:mm a" tz=timezone}}
+{{/with}}
+{{~/inline~}}
+
+{{~#*inline "format-month-date"~}}
+{{#with transaction.listing.availability-plan}}
+{{date date format="MMM d" tz=timezone}}
+{{/with}}
 {{~/inline~}}
 
 <html>
@@ -46,12 +60,12 @@
           <td class="right">End date</td>
         </tr>
         <tr>
-          <th class="left">{{date booking.start format="EE hh:mm a"}}</th>
-          <th class="right">{{date booking.end format="EE hh:mm a"}}</th>
+          <th class="left">{{> format-day-time date=booking.start}}</th>
+          <th class="right">{{> format-day-time date=booking.end}}</th>
         </tr>
         <tr class="bottom-row">
-          <th class="left">{{date booking.start format="MMM d"}}</th>
-          <th class="right">{{date booking.end format="MMM d"}}</th>
+          <th class="left">{{> format-month-date date=booking.start format="MMM d"}}</th>
+          <th class="right">{{> format-month-date date=booking.end format="MMM d"}}</th>
         </tr>
       </thead>
       <tbody>


### PR DESCRIPTION
Adds `tz` params for `date` helper invocations in email templates. In the time-based process the value is the availability plan timezone related to the listing in transaction. Others will default to to UTC.