### PR TITLE
Fix time based templates

### DIFF
--- a/preauth-unit-time-booking/templates/booking-request-accepted/booking-request-accepted-html.html
+++ b/preauth-unit-time-booking/templates/booking-request-accepted/booking-request-accepted-html.html
@@ -5,13 +5,13 @@
 
 {{~#*inline "format-date"~}}
 {{#with transaction.listing.availability-plan}}
-{{date date format="hh:mm a" tz=timezone}} on {{date date format="MMM d, YYYY" tz=timezone}}
+{{date date format="h:mm a" tz=timezone}} on {{date date format="MMM d, YYYY" tz=timezone}}
 {{/with}}
 {{~/inline~}}
 
 {{~#*inline "format-day-time"~}}
 {{#with transaction.listing.availability-plan}}
-{{date date format="EE hh:mm a" tz=timezone}}
+{{date date format="EE h:mm a" tz=timezone}}
 {{/with}}
 {{~/inline~}}
 

--- a/preauth-unit-time-booking/templates/booking-request-accepted/booking-request-accepted-html.html
+++ b/preauth-unit-time-booking/templates/booking-request-accepted/booking-request-accepted-html.html
@@ -5,7 +5,7 @@
 
 {{~#*inline "format-date"~}}
 {{#with transaction.listing.availability-plan}}
-{{date d format="hh:mm a" tz=timezone}} on {{date date format="MMM d, YYYY" tz=timezone}}
+{{date date format="hh:mm a" tz=timezone}} on {{date date format="MMM d, YYYY" tz=timezone}}
 {{/with}}
 {{~/inline~}}
 
@@ -66,8 +66,8 @@
             <th class="right">{{> format-day-time date=booking.end}}</th>
         </tr>
         <tr class="bottom-row">
-          <th class="left">{{> format-month-date date=booking.start format="MMM d"}}</th>
-          <th class="right">{{> format-month-date date=booking.end format="MMM d"}}</th>
+          <th class="left">{{> format-month-date date=booking.start}}</th>
+          <th class="right">{{> format-month-date date=booking.end}}</th>
         </tr>
       </thead>
       <tbody>

--- a/preauth-unit-time-booking/templates/booking-request-auto-declined/booking-request-auto-declined-html.html
+++ b/preauth-unit-time-booking/templates/booking-request-auto-declined/booking-request-auto-declined-html.html
@@ -1,7 +1,7 @@
 
 {{~#*inline "format-date"~}}
 {{#with transaction.listing.availability-plan}}
-{{date d format="hh:mm a" tz=timezone}} on {{date date format="MMM d, YYYY" tz=timezone}}
+{{date date format="hh:mm a" tz=timezone}} on {{date date format="MMM d, YYYY" tz=timezone}}
 {{/with}}
 {{~/inline~}}
 

--- a/preauth-unit-time-booking/templates/booking-request-auto-declined/booking-request-auto-declined-html.html
+++ b/preauth-unit-time-booking/templates/booking-request-auto-declined/booking-request-auto-declined-html.html
@@ -1,7 +1,7 @@
 
 {{~#*inline "format-date"~}}
 {{#with transaction.listing.availability-plan}}
-{{date date format="hh:mm a" tz=timezone}} on {{date date format="MMM d, YYYY" tz=timezone}}
+{{date date format="h:mm a" tz=timezone}} on {{date date format="MMM d, YYYY" tz=timezone}}
 {{/with}}
 {{~/inline~}}
 

--- a/preauth-unit-time-booking/templates/booking-request-declined/booking-request-declined-html.html
+++ b/preauth-unit-time-booking/templates/booking-request-declined/booking-request-declined-html.html
@@ -1,7 +1,7 @@
 
 {{~#*inline "format-date"~}}
 {{#with transaction.listing.availability-plan}}
-{{date d format="hh:mm a" tz=timezone}} on {{date date format="MMM d, YYYY" tz=timezone}}
+{{date date format="hh:mm a" tz=timezone}} on {{date date format="MMM d, YYYY" tz=timezone}}
 {{/with}}
 {{~/inline~}}
 

--- a/preauth-unit-time-booking/templates/booking-request-declined/booking-request-declined-html.html
+++ b/preauth-unit-time-booking/templates/booking-request-declined/booking-request-declined-html.html
@@ -1,7 +1,7 @@
 
 {{~#*inline "format-date"~}}
 {{#with transaction.listing.availability-plan}}
-{{date date format="hh:mm a" tz=timezone}} on {{date date format="MMM d, YYYY" tz=timezone}}
+{{date date format="h:mm a" tz=timezone}} on {{date date format="MMM d, YYYY" tz=timezone}}
 {{/with}}
 {{~/inline~}}
 

--- a/preauth-unit-time-booking/templates/money-paid/money-paid-html.html
+++ b/preauth-unit-time-booking/templates/money-paid/money-paid-html.html
@@ -5,13 +5,13 @@
 
 {{~#*inline "format-date"~}}
 {{#with transaction.listing.availability-plan}}
-{{date date format="hh:mm a" tz=timezone}} on {{date date format="MMM d, YYYY" tz=timezone}}
+{{date date format="h:mm a" tz=timezone}} on {{date date format="MMM d, YYYY" tz=timezone}}
 {{/with}}
 {{~/inline~}}
 
 {{~#*inline "format-day-time"~}}
 {{#with transaction.listing.availability-plan}}
-{{date date format="EE hh:mm a" tz=timezone}}
+{{date date format="EE h:mm a" tz=timezone}}
 {{/with}}
 {{~/inline~}}
 

--- a/preauth-unit-time-booking/templates/money-paid/money-paid-html.html
+++ b/preauth-unit-time-booking/templates/money-paid/money-paid-html.html
@@ -5,7 +5,7 @@
 
 {{~#*inline "format-date"~}}
 {{#with transaction.listing.availability-plan}}
-{{date d format="hh:mm a" tz=timezone}} on {{date date format="MMM d, YYYY" tz=timezone}}
+{{date date format="hh:mm a" tz=timezone}} on {{date date format="MMM d, YYYY" tz=timezone}}
 {{/with}}
 {{~/inline~}}
 
@@ -66,8 +66,8 @@
           <th class="right">{{> format-day-time date=booking.end}}</th>
         </tr>
         <tr class="bottom-row">
-          <th class="left">{{> format-month-date date=booking.start format="MMM d"}}</th>
-          <th class="right">{{> format-month-date date=booking.end format="MMM d"}}</th>
+          <th class="left">{{> format-month-date date=booking.start}}</th>
+          <th class="right">{{> format-month-date date=booking.end}}</th>
         </tr>
       </thead>
       <tbody>

--- a/preauth-unit-time-booking/templates/new-booking-request/new-booking-request-html.html
+++ b/preauth-unit-time-booking/templates/new-booking-request/new-booking-request-html.html
@@ -5,13 +5,13 @@
 
 {{~#*inline "format-date"~}}
 {{#with transaction.listing.availability-plan}}
-{{date date format="hh:mm a" tz=timezone}} on {{date date format="MMM d, YYYY" tz=timezone}}
+{{date date format="h:mm a" tz=timezone}} on {{date date format="MMM d, YYYY" tz=timezone}}
 {{/with}}
 {{~/inline~}}
 
 {{~#*inline "format-day-time"~}}
 {{#with transaction.listing.availability-plan}}
-{{date date format="EE hh:mm a" tz=timezone}}
+{{date date format="EE h:mm a" tz=timezone}}
 {{/with}}
 {{~/inline~}}
 

--- a/preauth-unit-time-booking/templates/new-booking-request/new-booking-request-html.html
+++ b/preauth-unit-time-booking/templates/new-booking-request/new-booking-request-html.html
@@ -5,7 +5,7 @@
 
 {{~#*inline "format-date"~}}
 {{#with transaction.listing.availability-plan}}
-{{date d format="hh:mm a" tz=timezone}} on {{date date format="MMM d, YYYY" tz=timezone}}
+{{date date format="hh:mm a" tz=timezone}} on {{date date format="MMM d, YYYY" tz=timezone}}
 {{/with}}
 {{~/inline~}}
 
@@ -64,8 +64,8 @@
           <th class="right">{{> format-day-time date=booking.end}}</th>
         </tr>
         <tr class="bottom-row">
-          <th class="left">{{> format-month-date date=booking.start format="MMM d"}}</th>
-          <th class="right">{{> format-month-date date=booking.end format="MMM d"}}</th>
+          <th class="left">{{> format-month-date date=booking.start}}</th>
+          <th class="right">{{> format-month-date date=booking.end}}</th>
         </tr>
       </thead>
       <tbody>


### PR DESCRIPTION
Fixes an inline date formatting helper.

Improves showing times with in 12h format so that two digits are not used for the hour if not needed: 09:45 PM -> 9:45 PM.