### PR TITLE
Change expiration time of the booking in unit-time process

### DIFF
--- a/preauth-unit-time-booking/process.edn
+++ b/preauth-unit-time-booking/process.edn
@@ -62,8 +62,7 @@
     [{:fn/plus
       [{:fn/timepoint [:time/first-entered-state :state/preauthorized]}
        {:fn/period ["P6D"]}]}
-     {:fn/plus
-      [{:fn/timepoint [:time/booking-end]} {:fn/period ["P1D"]}]}]},
+       {:fn/timepoint [:time/booking-start]} ]},
    :actions
    [{:name :action/decline-booking}
     {:name :action/calculate-full-refund}


### PR DESCRIPTION
With the time-based process, it might not be a good default that the provider can accept the booking day after the booking has ended. I think a better option would be that the booking expires by the booking start time if the provider has not accepted or declined it. 