### PR TITLE
Fix failing transaction id links

### DIFF
--- a/automatic-off-session-payment/templates/booking-review-by-customer-wanted/booking-review-by-customer-wanted-html.html
+++ b/automatic-off-session-payment/templates/booking-review-by-customer-wanted/booking-review-by-customer-wanted-html.html
@@ -22,7 +22,6 @@
                 {{listing.title}} from
                 {{provider.display-name}}. Please leave a review to describe your experience.</p>
 
-              {{/with}}
               <table style="padding:16px 0 0" align="center" role="presentation" cellSpacing="0" cellPadding="0"
                 border="0" width="100%">
                 <tbody>
@@ -42,6 +41,7 @@
                   </tr>
                 </tbody>
               </table>
+              {{/with}}
               <div>
                 <hr style="width:100%;border:none;border-top:1px solid #eaeaea;border-color:#E1E1E1;margin:20px 0" />
                 <p

--- a/instant-booking/templates/booking-review-by-customer-wanted/booking-review-by-customer-wanted-html.html
+++ b/instant-booking/templates/booking-review-by-customer-wanted/booking-review-by-customer-wanted-html.html
@@ -22,7 +22,6 @@
                 {{listing.title}} from
                 {{provider.display-name}}. Please leave a review to describe your experience.</p>
 
-              {{/with}}
               <table style="padding:16px 0 0" align="center" role="presentation" cellSpacing="0" cellPadding="0"
                 border="0" width="100%">
                 <tbody>
@@ -41,6 +40,7 @@
                   </tr>
                 </tbody>
               </table>
+              {{/with}}
               <div>
                 <hr style="width:100%;border:none;border-top:1px solid #eaeaea;border-color:#E1E1E1;margin:20px 0" />
                 <p


### PR DESCRIPTION
Two email templates had an issue with transaction links not working, because the `{{#with transaction}}` block ended too early. This change fixes those templates.